### PR TITLE
Staged move generation + TT hash move (+131 Elo)

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1,4 +1,7 @@
 
+#include <array>
+#include <chrono>
+#include <utility>
 #include "attacks.h"
 #include "movegen.h"
 
@@ -628,6 +631,356 @@ getSmallestAttacker(const ChessBoard& pos, const Square square, Color side, Bitb
   return side == WHITE
     ? getSmallestAttackerImpl<WHITE>(pos, square, removedPieces)
     : getSmallestAttackerImpl<BLACK>(pos, square, removedPieces);
+}
+
+#endif
+
+
+#ifndef HASH_MOVE_LEGAL
+
+// ----- King-ray dispatch table used by pinnedRayDest_fast ---------------------
+// Each square is on at most one of the eight king-aligned rays. rayDirection()
+// computes which one (or DIR_NONE) in pure arithmetic, then we look the ray
+// up in RAY_DISPATCH instead of trying all eight in sequence.
+
+namespace {
+
+constexpr int DIR_NONE = 8;
+
+// 15x15 lookup keyed on (dr+7, df+7), dr/df in [-7, 7]. One IMUL, one ADD,
+// one byte load -- no branches. Built once at program load via constexpr.
+//   0 right  1 left   2 up        3 down
+//   4 upRt   5 upLft  6 dnRt      7 dnLft   8 not on any ray
+constexpr auto RAY_DIR_LUT = []() {
+  std::array<uint8_t, 15 * 15> t{};
+  for (auto& v : t) v = uint8_t(DIR_NONE);
+  for (int dr = -7; dr <= 7; ++dr)
+    for (int df = -7; df <= 7; ++df)
+    {
+      int code = DIR_NONE;
+      if (dr == 0 && df == 0)             code = DIR_NONE;
+      else if (dr == 0)                   code = df > 0 ? 0 : 1;
+      else if (df == 0)                   code = dr > 0 ? 2 : 3;
+      else if (dr ==  df)                 code = dr > 0 ? 4 : 7;
+      else if (dr == -df)                 code = dr > 0 ? 5 : 6;
+      t[size_t((dr + 7) * 15 + (df + 7))] = uint8_t(code);
+    }
+  return t;
+}();
+
+static inline int
+rayDirection(Square from, Square to) noexcept
+{
+  const int dr = (int(to) >> 3) - (int(from) >> 3);
+  const int df = (int(to) &  7) - (int(from) &  7);
+  return RAY_DIR_LUT[size_t((dr + 7) * 15 + (df + 7))];
+}
+
+struct RayDispatch
+{
+  const MaskTable* table;
+  BitboardFunc     closestToKing;   // lsb for rays toward higher squares, msb otherwise
+  bool             diagonal;        // false: pinner must be R/Q; true: B/Q
+};
+
+static constexpr RayDispatch RAY_DISPATCH[8] = {
+  { &plt::rightMasks    , lsb, false },           // 0 right
+  { &plt::leftMasks     , msb, false },           // 1 left
+  { &plt::upMasks       , lsb, false },           // 2 up
+  { &plt::downMasks     , msb, false },           // 3 down
+  { &plt::upRightMasks  , lsb, true  },           // 4 upRight
+  { &plt::upLeftMasks   , lsb, true  },           // 5 upLeft
+  { &plt::downRightMasks, msb, true  },           // 6 downRight
+  { &plt::downLeftMasks , msb, true  },           // 7 downLeft
+};
+
+} // namespace
+
+// Like pinnedRayDest below, but uses rayDirection(kpos, ip) to jump straight
+// to the one ray that could contain `ip`, avoiding up to seven masked-load +
+// AND tests on the common "ip not on any king ray" path.
+template <Color cMy>
+static bool
+pinnedRayDest_fast(const ChessBoard& pos, Square ip, Square kpos, Bitboard& destSq) noexcept
+{
+  const int dir = rayDirection(kpos, ip);
+  if (dir == DIR_NONE) return false;
+
+  constexpr Color cEmy = ~cMy;
+  const RayDispatch& d = RAY_DISPATCH[dir];
+  const Bitboard sliders = d.diagonal
+    ? (pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, BISHOP>())
+    : (pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, ROOK  >());
+
+  const MaskTable& table = *d.table;
+  const Bitboard ray   = table[kpos];
+  const Bitboard ipBit = 1ULL << ip;
+  const Bitboard pieces = ray & pos.all();
+
+  const Bitboard first = d.closestToKing(pieces);
+  if (first != ipBit) return false;               // a blocker sits between king and ip
+
+  const Bitboard second = d.closestToKing(pieces ^ first);
+  if (!(second & sliders)) return false;          // no pinner behind ip
+
+  destSq = ray ^ table[squareNo(second)] ^ ipBit;
+  return true;
+}
+
+// If the piece on `ip` is pinned against our king, fills `destSq` with the
+// squares it may legally move to (the squares between king and pinner, plus the
+// pinner's square, minus `ip`) and returns true. Otherwise leaves `destSq`
+// untouched and returns false. Only the single ray that could contain `ip` is
+// ever examined.
+//
+// Superseded by pinnedRayDest_fast (which uses rayDirection() to skip the
+// per-direction `ray & ipBit` probes). Kept here as a reference / fallback.
+template <Color cMy>
+[[maybe_unused]] static bool
+pinnedRayDest(const ChessBoard& pos, Square ip, Square kpos, Bitboard& destSq) noexcept
+{
+  constexpr Color cEmy = ~cMy;
+  const Bitboard ipBit = 1ULL << ip;
+  const Bitboard occupied = pos.all();
+  const Bitboard erq = pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, ROOK  >();
+  const Bitboard ebq = pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, BISHOP>();
+
+  // -1 -> ip not on this ray; 0 -> on ray but not pinned; 1 -> pinned (destSq set)
+  const auto scan = [&] (const MaskTable& table, BitboardFunc closest, Bitboard sliders) -> int
+  {
+    const Bitboard ray = table[kpos];
+    if (!(ray & ipBit)) return -1;
+
+    const Bitboard pieces = ray & occupied;
+    const Bitboard first  = closest(pieces);
+    if (first != ipBit) return 0;                 // a blocker sits between king and ip
+
+    const Bitboard second = closest(pieces ^ first);
+    if (!(second & sliders)) return 0;            // nothing pinning behind ip
+
+    destSq = ray ^ table[squareNo(second)] ^ ipBit;
+    return 1;
+  };
+
+  int r;
+  if ((r = scan(plt::rightMasks    , lsb, erq)) != -1) return r == 1;
+  if ((r = scan(plt::leftMasks     , msb, erq)) != -1) return r == 1;
+  if ((r = scan(plt::upMasks       , lsb, erq)) != -1) return r == 1;
+  if ((r = scan(plt::downMasks     , msb, erq)) != -1) return r == 1;
+  if ((r = scan(plt::upRightMasks  , lsb, ebq)) != -1) return r == 1;
+  if ((r = scan(plt::upLeftMasks   , lsb, ebq)) != -1) return r == 1;
+  if ((r = scan(plt::downRightMasks, msb, ebq)) != -1) return r == 1;
+  if ((r = scan(plt::downLeftMasks , msb, ebq)) != -1) return r == 1;
+  return false;
+}
+
+// ----- micro-benchmark: pinnedRayDest vs pinnedRayDest_fast --------------------
+// Runs each function `iters` times over every non-king own-side piece in `pos`
+// (`pos.color`) and returns the total wall time in seconds. The accumulator
+// (`sink`) is XORed into a volatile to keep the compiler from folding the loops
+// away. Both variants get the same input set and are timed back-to-back; for a
+// single position the absolute numbers are noisy, so the caller should sum them
+// over many positions before drawing conclusions.
+template <Color cMy>
+static std::pair<double, double>
+benchmarkPinnedRayDestImpl(const ChessBoard& pos, int iters) noexcept
+{
+  const Square kpos = squareNo(pos.piece<cMy, KING>());
+
+  Square pieces[16];
+  int    pieceCount = 0;
+  Bitboard own = pos.piece<cMy, PAWN>()  | pos.piece<cMy, BISHOP>()
+               | pos.piece<cMy, KNIGHT>()| pos.piece<cMy, ROOK>()
+               | pos.piece<cMy, QUEEN>();
+  while (own && pieceCount < 16)
+  {
+    const Bitboard b = own & -own;
+    pieces[pieceCount++] = squareNo(b);
+    own ^= b;
+  }
+
+  volatile Bitboard volSink = 0;
+  Bitboard sinkSlow = 0, sinkFast = 0;
+
+  using clock = std::chrono::high_resolution_clock;
+
+  const auto t0 = clock::now();
+  for (int it = 0; it < iters; ++it)
+    for (int i = 0; i < pieceCount; ++i)
+    {
+      Bitboard dst = AllSquares;
+      pinnedRayDest<cMy>(pos, pieces[i], kpos, dst);
+      sinkSlow ^= dst;
+    }
+  const auto t1 = clock::now();
+  for (int it = 0; it < iters; ++it)
+    for (int i = 0; i < pieceCount; ++i)
+    {
+      Bitboard dst = AllSquares;
+      pinnedRayDest_fast<cMy>(pos, pieces[i], kpos, dst);
+      sinkFast ^= dst;
+    }
+  const auto t2 = clock::now();
+
+  volSink = sinkSlow ^ sinkFast;
+  (void) volSink;
+
+  return {
+    std::chrono::duration<double>(t1 - t0).count(),
+    std::chrono::duration<double>(t2 - t1).count()
+  };
+}
+
+std::pair<double, double>
+benchmarkPinnedRayDest(const ChessBoard& pos, int iters)
+{
+  return (pos.color == WHITE)
+    ? benchmarkPinnedRayDestImpl<WHITE>(pos, iters)
+    : benchmarkPinnedRayDestImpl<BLACK>(pos, iters);
+}
+
+template <Color cMy>
+static bool
+isHashMoveLegalImpl(Move move, const ChessBoard& pos, const MoveList& meta) noexcept
+{
+  constexpr Color    cEmy      = ~cMy;
+  constexpr int      pawnPush  = (cMy == WHITE) ? 8 : -8;
+  constexpr Bitboard startRank = (cMy == WHITE) ? Rank2 : Rank7;
+
+  const Square ip = from_sq(move);
+  const Square fp = to_sq(move);
+  if (ip == fp) return false;
+
+  const Piece ipPiece = pos.pieceOnSquare(ip);
+  if (ipPiece == NO_PIECE || color_of(ipPiece) != cMy) return false;
+
+  const PieceType ipt = type_of(ipPiece);
+  if (PieceType((move >> 12) & 7) != ipt) return false;                 // pIp field
+
+  const Piece fpPiece = pos.pieceOnSquare(fp);
+  if (fpPiece != NO_PIECE && color_of(fpPiece) == cMy) return false;    // can't capture own
+  if (PieceType((move >> 15) & 7) != type_of(fpPiece)) return false;    // pFp field (NONE on empty / e.p. target)
+
+  const Bitboard ipBit = 1ULL << ip;
+  const Bitboard fpBit = 1ULL << fp;
+  const Bitboard occupied = pos.all();
+  const Square kpos = squareNo(pos.piece<cMy, KING>());
+
+  // --------------------------------------------------------------------- King
+  if (ipt == KING)
+  {
+    const int diff = int(fp) - int(ip);
+
+    if (diff == 2 || diff == -2)                                        // castling
+    {
+      if (meta.checkers != 0) return false;                            // never out of check
+      const Bitboard attacked = meta.enemyAttackedSquares;
+      if (ipBit & attacked) return false;                              // (king-square attacked => in check)
+
+      constexpr int shift = 56 * int(cEmy);
+      if (int(ip) != shift + 4) return false;                          // king must be on its home square
+
+      const Bitboard covered = occupied | attacked;
+      if (diff == 2)                                                   // king side
+      {
+        constexpr int      kingSide = 256 << (2 * int(cMy));
+        constexpr Bitboard rSq      = 96ULL << shift;                  // f1/g1 (or f8/g8)
+        if (!(pos.csep & kingSide)) return false;
+        if (rSq & covered) return false;
+        return true;
+      }
+      // queen side
+      constexpr int      queenSide = 128 << (2 * int(cMy));
+      constexpr Bitboard lMidSq    = 2ULL  << shift;                   // b1 (or b8)
+      constexpr Bitboard lSq       = 12ULL << shift;                   // c1/d1 (or c8/d8)
+      if (!(pos.csep & queenSide)) return false;
+      if (occupied & lMidSq) return false;
+      if (lSq & covered) return false;
+      return true;
+    }
+
+    // ordinary king step
+    if (!(plt::kingMasks[ip] & fpBit)) return false;
+    if (fpBit & meta.enemyAttackedSquares) return false;
+    return true;
+  }
+
+  // any non-king move is impossible under double check
+  if (meta.checkers >= 2) return false;
+
+  // pin ray + (when in check) the squares that block / capture the checker
+  Bitboard pinMask = AllSquares;
+  // Old: pinnedRayDest<cMy>(pos, ip, kpos, pinMask) — 8-direction scan, kept above for reference.
+  const bool pinned = pinnedRayDest_fast<cMy>(pos, ip, kpos, pinMask);  // pinMask unchanged if not pinned
+  const Bitboard checkMask = (meta.checkers == 1) ? meta.legalSquaresMaskInCheck : AllSquares;
+
+  // --------------------------------------------------------------------- Pawn
+  if (ipt == PAWN)
+  {
+    const Square ep = pos.enPassantSquare();
+
+    if (fpBit & plt::pawnCaptureMasks[cMy][ip])                        // diagonal -> capture or e.p.
+    {
+      if (ep != SQUARE_NB && fp == ep)                                // en passant
+      {
+        const Square capSq = fp - pawnPush;                           // the pawn we remove
+        if (pos.pieceOnSquare(capSq) != make_piece(cEmy, PAWN)) return false;
+        if (meta.checkers == 1
+          && !(plt::pawnCaptureMasks[cMy][kpos] & pos.piece<cEmy, PAWN>())) return false;
+        if (!(fpBit & pinMask)) return false;
+        // When the pawn is pinned along its capture diagonal, the pin already
+        // guarantees safety w.r.t. that slider — generation's pinsCheck branch
+        // skips enpassantRecheck for exactly this reason; mirror it here.
+        if (!pinned && !enpassantRecheck<cMy>(ip, pos)) return false;
+        return true;
+      }
+      if (fpPiece == NO_PIECE) return false;                          // nothing there to capture
+      // (enemy colour and pFp already validated above)
+    }
+    else                                                              // straight push
+    {
+      if (fpPiece != NO_PIECE) return false;
+      if (int(fp) == int(ip) + pawnPush)
+        ;                                                             // single push
+      else if (int(fp) == int(ip) + 2 * pawnPush && (ipBit & startRank))
+      {
+        if (pos.pieceOnSquare(Square(int(ip) + pawnPush)) != NO_PIECE) return false;
+      }
+      else return false;
+    }
+
+    if (!(fpBit & checkMask)) return false;
+    if (!(fpBit & pinMask)) return false;
+    return true;
+  }
+
+  // ------------------------------------------------------------------- Knight
+  if (ipt == KNIGHT)
+  {
+    if (!(plt::knightMasks[ip] & fpBit)) return false;
+    if (!(fpBit & checkMask)) return false;
+    if (!(fpBit & pinMask)) return false;                             // a pinned knight can never move
+    return true;
+  }
+
+  // ----------------------------------------------------- Bishop / Rook / Queen
+  Bitboard reachable;
+  if      (ipt == BISHOP) reachable = attackSquares<BISHOP>(ip, occupied);
+  else if (ipt == ROOK  ) reachable = attackSquares<ROOK  >(ip, occupied);
+  else                    reachable = attackSquares<QUEEN >(ip, occupied);
+
+  if (!(reachable & fpBit)) return false;
+  if (!(fpBit & checkMask)) return false;
+  if (!(fpBit & pinMask)) return false;
+  return true;
+}
+
+bool
+isHashMoveLegal(Move move, const ChessBoard& pos, const MoveList& meta)
+{
+  return pos.color == WHITE
+    ? isHashMoveLegalImpl<WHITE>(move, pos, meta)
+    : isHashMoveLegalImpl<BLACK>(move, pos, meta);
 }
 
 #endif

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include <array>
 #include <chrono>
 #include <utility>
@@ -41,6 +41,199 @@ isLegalMoveForPosition(Move move, const ChessBoard& pos)
     if (filter(move) == filter(legalMove)) return true;
 
   return false;
+}
+
+
+template <Color cMy>
+static bool
+isLegalMoveForPosition_V2_impl(Move move, const ChessBoard& pos)
+{
+  constexpr Color cEmy = ~cMy;
+
+  Square ip = Square(move & 0x3f);
+  Square fp = Square((move >> 6) & 0x3f);
+
+  if (ip == fp)
+    return false;
+
+  Piece movingPc = pos.pieceOnSquare(ip);
+  if (movingPc == NO_PIECE || color_of(movingPc) != cMy)
+    return false;
+
+  Piece capturedPc = pos.pieceOnSquare(fp);
+  if (capturedPc != NO_PIECE && (color_of(capturedPc) == cMy || type_of(capturedPc) == KING))
+    return false;
+
+  PieceType pt = type_of(movingPc);
+
+  Bitboard fromBb = 1ULL << ip;
+  Bitboard toBb   = 1ULL << fp;
+  Bitboard occ    = pos.all();
+  Bitboard occAfter = (occ ^ fromBb) | toBb;
+
+  Bitboard ePawn   = pos.piece<cEmy, PAWN  >();
+  Bitboard eKnight = pos.piece<cEmy, KNIGHT>();
+  Bitboard eBishop = pos.piece<cEmy, BISHOP>();
+  Bitboard eRook   = pos.piece<cEmy, ROOK  >();
+  Bitboard eQueen  = pos.piece<cEmy, QUEEN >();
+  Bitboard eKing   = pos.piece<cEmy, KING  >();
+
+  const auto squareAttacked = [&] (Square sq, Bitboard o) -> bool
+  {
+    if (attackSquares<KNIGHT>(sq, o) & eKnight) return true;
+    if (attackSquares< ROOK >(sq, o) & (eRook   | eQueen)) return true;
+    if (attackSquares<BISHOP>(sq, o) & (eBishop | eQueen)) return true;
+    if (attackSquares<cMy, PAWN>(sq) &  ePawn)  return true;
+    if (plt::kingMasks[sq]           &  eKing)  return true;
+    return false;
+  };
+
+  Square epCapturedSq = SQUARE_NB;
+
+  if (pt == KNIGHT)
+  {
+    if ((plt::knightMasks[ip] & toBb) == 0) return false;
+  }
+  else if (pt == BISHOP)
+  {
+    if ((attackSquares<BISHOP>(ip, occ) & toBb) == 0) return false;
+  }
+  else if (pt == ROOK)
+  {
+    if ((attackSquares<ROOK>(ip, occ) & toBb) == 0) return false;
+  }
+  else if (pt == QUEEN)
+  {
+    if ((attackSquares<QUEEN>(ip, occ) & toBb) == 0) return false;
+  }
+  else if (pt == PAWN)
+  {
+    constexpr int      forward    = (cMy == WHITE) ? 8 : -8;
+    constexpr Bitboard startRank  = (cMy == WHITE) ? Rank2 : Rank7;
+
+    int delta    = int(fp) - int(ip);
+    int fileDiff = std::abs((ip & 7) - (fp & 7));
+    bool isCapture = (capturedPc != NO_PIECE);
+
+    if (delta == forward + 1 || delta == forward - 1)
+    {
+      if (fileDiff != 1) return false;
+
+      if (!isCapture)
+      {
+        Square eps = pos.enPassantSquare();
+        if (eps == SQUARE_NB || fp != eps) return false;
+        epCapturedSq = Square(int(fp) - forward);
+        if (!(ePawn & (1ULL << epCapturedSq))) return false;
+        occAfter ^= 1ULL << epCapturedSq;
+        ePawn   ^= 1ULL << epCapturedSq;
+      }
+    }
+    else if (delta == forward)
+    {
+      if (isCapture) return false;
+    }
+    else if (delta == 2 * forward)
+    {
+      if ((fromBb & startRank) == 0) return false;
+      if (isCapture) return false;
+      Square between = Square(int(ip) + forward);
+      if (occ & (1ULL << between)) return false;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else if (pt == KING)
+  {
+    int fileDiff = std::abs((ip & 7) - (fp & 7));
+    int rankDiff = std::abs((ip >> 3) - (fp >> 3));
+
+    if (fileDiff <= 1 && rankDiff <= 1)
+    {
+      if ((plt::kingMasks[ip] & toBb) == 0) return false;
+    }
+    else if (rankDiff == 0 && fileDiff == 2)
+    {
+      constexpr int      shift     = 56 * cEmy;
+      constexpr Bitboard rGap      = 96ULL << shift;
+      constexpr Bitboard lGap      = 12ULL << shift;
+      constexpr Bitboard lExtra    =  2ULL << shift;
+      constexpr int      kingSide  = 256 << (2 * cMy);
+      constexpr int      queenSide = 128 << (2 * cMy);
+      constexpr Square   kingHome  = Square(shift + 4);
+
+      if (ip != kingHome) return false;
+      if (squareAttacked(ip, occ)) return false;
+
+      bool isKingside  = (fp == Square(shift + 6));
+      bool isQueenside = (fp == Square(shift + 2));
+      if (!isKingside && !isQueenside) return false;
+
+      Bitboard transit;
+      if (isKingside)
+      {
+        if (!(pos.csep & kingSide)) return false;
+        if (rGap & occ) return false;
+        transit = rGap;
+      }
+      else
+      {
+        if (!(pos.csep & queenSide)) return false;
+        if ((lGap | lExtra) & occ) return false;
+        transit = lGap;
+      }
+
+      while (transit)
+      {
+        Square s = nextSquare(transit);
+        if (squareAttacked(s, occ)) return false;
+      }
+
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else
+  {
+    return false;
+  }
+
+  if (capturedPc != NO_PIECE && epCapturedSq == SQUARE_NB)
+  {
+    Bitboard cMask = ~toBb;
+    switch (type_of(capturedPc))
+    {
+      case PAWN:   ePawn   &= cMask; break;
+      case KNIGHT: eKnight &= cMask; break;
+      case BISHOP: eBishop &= cMask; break;
+      case ROOK:   eRook   &= cMask; break;
+      case QUEEN:  eQueen  &= cMask; break;
+      default: break;
+    }
+  }
+
+  Square kSq = (pt == KING) ? fp : squareNo(pos.piece<cMy, KING>());
+
+  if (attackSquares<KNIGHT>(kSq, occAfter) & eKnight) return false;
+  if (attackSquares< ROOK >(kSq, occAfter) & (eRook   | eQueen)) return false;
+  if (attackSquares<BISHOP>(kSq, occAfter) & (eBishop | eQueen)) return false;
+  if (attackSquares<cMy, PAWN>(kSq)        &  ePawn)  return false;
+  if (pt == KING && (plt::kingMasks[kSq]   &  eKing)) return false;
+
+  return true;
+}
+
+bool
+isLegalMoveForPosition_V2(Move move, const ChessBoard& pos)
+{
+  return pos.color == WHITE
+    ? isLegalMoveForPosition_V2_impl<WHITE>(move, pos)
+    : isLegalMoveForPosition_V2_impl<BLACK>(move, pos);
 }
 
 
@@ -634,354 +827,3 @@ getSmallestAttacker(const ChessBoard& pos, const Square square, Color side, Bitb
 }
 
 #endif
-
-
-#ifndef HASH_MOVE_LEGAL
-
-// ----- King-ray dispatch table used by pinnedRayDest_fast ---------------------
-// Each square is on at most one of the eight king-aligned rays. rayDirection()
-// computes which one (or DIR_NONE) in pure arithmetic, then we look the ray
-// up in RAY_DISPATCH instead of trying all eight in sequence.
-
-namespace {
-
-constexpr int DIR_NONE = 8;
-
-// 15x15 lookup keyed on (dr+7, df+7), dr/df in [-7, 7]. One IMUL, one ADD,
-// one byte load -- no branches. Built once at program load via constexpr.
-//   0 right  1 left   2 up        3 down
-//   4 upRt   5 upLft  6 dnRt      7 dnLft   8 not on any ray
-constexpr auto RAY_DIR_LUT = []() {
-  std::array<uint8_t, 15 * 15> t{};
-  for (auto& v : t) v = uint8_t(DIR_NONE);
-  for (int dr = -7; dr <= 7; ++dr)
-    for (int df = -7; df <= 7; ++df)
-    {
-      int code = DIR_NONE;
-      if (dr == 0 && df == 0)             code = DIR_NONE;
-      else if (dr == 0)                   code = df > 0 ? 0 : 1;
-      else if (df == 0)                   code = dr > 0 ? 2 : 3;
-      else if (dr ==  df)                 code = dr > 0 ? 4 : 7;
-      else if (dr == -df)                 code = dr > 0 ? 5 : 6;
-      t[size_t((dr + 7) * 15 + (df + 7))] = uint8_t(code);
-    }
-  return t;
-}();
-
-static inline int
-rayDirection(Square from, Square to) noexcept
-{
-  const int dr = (int(to) >> 3) - (int(from) >> 3);
-  const int df = (int(to) &  7) - (int(from) &  7);
-  return RAY_DIR_LUT[size_t((dr + 7) * 15 + (df + 7))];
-}
-
-struct RayDispatch
-{
-  const MaskTable* table;
-  BitboardFunc     closestToKing;   // lsb for rays toward higher squares, msb otherwise
-  bool             diagonal;        // false: pinner must be R/Q; true: B/Q
-};
-
-static constexpr RayDispatch RAY_DISPATCH[8] = {
-  { &plt::rightMasks    , lsb, false },           // 0 right
-  { &plt::leftMasks     , msb, false },           // 1 left
-  { &plt::upMasks       , lsb, false },           // 2 up
-  { &plt::downMasks     , msb, false },           // 3 down
-  { &plt::upRightMasks  , lsb, true  },           // 4 upRight
-  { &plt::upLeftMasks   , lsb, true  },           // 5 upLeft
-  { &plt::downRightMasks, msb, true  },           // 6 downRight
-  { &plt::downLeftMasks , msb, true  },           // 7 downLeft
-};
-
-} // namespace
-
-// Like pinnedRayDest below, but uses rayDirection(kpos, ip) to jump straight
-// to the one ray that could contain `ip`, avoiding up to seven masked-load +
-// AND tests on the common "ip not on any king ray" path.
-template <Color cMy>
-static bool
-pinnedRayDest_fast(const ChessBoard& pos, Square ip, Square kpos, Bitboard& destSq) noexcept
-{
-  const int dir = rayDirection(kpos, ip);
-  if (dir == DIR_NONE) return false;
-
-  constexpr Color cEmy = ~cMy;
-  const RayDispatch& d = RAY_DISPATCH[dir];
-  const Bitboard sliders = d.diagonal
-    ? (pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, BISHOP>())
-    : (pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, ROOK  >());
-
-  const MaskTable& table = *d.table;
-  const Bitboard ray   = table[kpos];
-  const Bitboard ipBit = 1ULL << ip;
-  const Bitboard pieces = ray & pos.all();
-
-  const Bitboard first = d.closestToKing(pieces);
-  if (first != ipBit) return false;               // a blocker sits between king and ip
-
-  const Bitboard second = d.closestToKing(pieces ^ first);
-  if (!(second & sliders)) return false;          // no pinner behind ip
-
-  destSq = ray ^ table[squareNo(second)] ^ ipBit;
-  return true;
-}
-
-// If the piece on `ip` is pinned against our king, fills `destSq` with the
-// squares it may legally move to (the squares between king and pinner, plus the
-// pinner's square, minus `ip`) and returns true. Otherwise leaves `destSq`
-// untouched and returns false. Only the single ray that could contain `ip` is
-// ever examined.
-//
-// Superseded by pinnedRayDest_fast (which uses rayDirection() to skip the
-// per-direction `ray & ipBit` probes). Kept here as a reference / fallback.
-template <Color cMy>
-[[maybe_unused]] static bool
-pinnedRayDest(const ChessBoard& pos, Square ip, Square kpos, Bitboard& destSq) noexcept
-{
-  constexpr Color cEmy = ~cMy;
-  const Bitboard ipBit = 1ULL << ip;
-  const Bitboard occupied = pos.all();
-  const Bitboard erq = pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, ROOK  >();
-  const Bitboard ebq = pos.piece<cEmy, QUEEN>() | pos.piece<cEmy, BISHOP>();
-
-  // -1 -> ip not on this ray; 0 -> on ray but not pinned; 1 -> pinned (destSq set)
-  const auto scan = [&] (const MaskTable& table, BitboardFunc closest, Bitboard sliders) -> int
-  {
-    const Bitboard ray = table[kpos];
-    if (!(ray & ipBit)) return -1;
-
-    const Bitboard pieces = ray & occupied;
-    const Bitboard first  = closest(pieces);
-    if (first != ipBit) return 0;                 // a blocker sits between king and ip
-
-    const Bitboard second = closest(pieces ^ first);
-    if (!(second & sliders)) return 0;            // nothing pinning behind ip
-
-    destSq = ray ^ table[squareNo(second)] ^ ipBit;
-    return 1;
-  };
-
-  int r;
-  if ((r = scan(plt::rightMasks    , lsb, erq)) != -1) return r == 1;
-  if ((r = scan(plt::leftMasks     , msb, erq)) != -1) return r == 1;
-  if ((r = scan(plt::upMasks       , lsb, erq)) != -1) return r == 1;
-  if ((r = scan(plt::downMasks     , msb, erq)) != -1) return r == 1;
-  if ((r = scan(plt::upRightMasks  , lsb, ebq)) != -1) return r == 1;
-  if ((r = scan(plt::upLeftMasks   , lsb, ebq)) != -1) return r == 1;
-  if ((r = scan(plt::downRightMasks, msb, ebq)) != -1) return r == 1;
-  if ((r = scan(plt::downLeftMasks , msb, ebq)) != -1) return r == 1;
-  return false;
-}
-
-// ----- micro-benchmark: pinnedRayDest vs pinnedRayDest_fast --------------------
-// Runs each function `iters` times over every non-king own-side piece in `pos`
-// (`pos.color`) and returns the total wall time in seconds. The accumulator
-// (`sink`) is XORed into a volatile to keep the compiler from folding the loops
-// away. Both variants get the same input set and are timed back-to-back; for a
-// single position the absolute numbers are noisy, so the caller should sum them
-// over many positions before drawing conclusions.
-template <Color cMy>
-static std::pair<double, double>
-benchmarkPinnedRayDestImpl(const ChessBoard& pos, int iters) noexcept
-{
-  const Square kpos = squareNo(pos.piece<cMy, KING>());
-
-  Square pieces[16];
-  int    pieceCount = 0;
-  Bitboard own = pos.piece<cMy, PAWN>()  | pos.piece<cMy, BISHOP>()
-               | pos.piece<cMy, KNIGHT>()| pos.piece<cMy, ROOK>()
-               | pos.piece<cMy, QUEEN>();
-  while (own && pieceCount < 16)
-  {
-    const Bitboard b = own & -own;
-    pieces[pieceCount++] = squareNo(b);
-    own ^= b;
-  }
-
-  volatile Bitboard volSink = 0;
-  Bitboard sinkSlow = 0, sinkFast = 0;
-
-  using clock = std::chrono::high_resolution_clock;
-
-  const auto t0 = clock::now();
-  for (int it = 0; it < iters; ++it)
-    for (int i = 0; i < pieceCount; ++i)
-    {
-      Bitboard dst = AllSquares;
-      pinnedRayDest<cMy>(pos, pieces[i], kpos, dst);
-      sinkSlow ^= dst;
-    }
-  const auto t1 = clock::now();
-  for (int it = 0; it < iters; ++it)
-    for (int i = 0; i < pieceCount; ++i)
-    {
-      Bitboard dst = AllSquares;
-      pinnedRayDest_fast<cMy>(pos, pieces[i], kpos, dst);
-      sinkFast ^= dst;
-    }
-  const auto t2 = clock::now();
-
-  volSink = sinkSlow ^ sinkFast;
-  (void) volSink;
-
-  return {
-    std::chrono::duration<double>(t1 - t0).count(),
-    std::chrono::duration<double>(t2 - t1).count()
-  };
-}
-
-std::pair<double, double>
-benchmarkPinnedRayDest(const ChessBoard& pos, int iters)
-{
-  return (pos.color == WHITE)
-    ? benchmarkPinnedRayDestImpl<WHITE>(pos, iters)
-    : benchmarkPinnedRayDestImpl<BLACK>(pos, iters);
-}
-
-template <Color cMy>
-static bool
-isHashMoveLegalImpl(Move move, const ChessBoard& pos, const MoveList& meta) noexcept
-{
-  constexpr Color    cEmy      = ~cMy;
-  constexpr int      pawnPush  = (cMy == WHITE) ? 8 : -8;
-  constexpr Bitboard startRank = (cMy == WHITE) ? Rank2 : Rank7;
-
-  const Square ip = from_sq(move);
-  const Square fp = to_sq(move);
-  if (ip == fp) return false;
-
-  const Piece ipPiece = pos.pieceOnSquare(ip);
-  if (ipPiece == NO_PIECE || color_of(ipPiece) != cMy) return false;
-
-  const PieceType ipt = type_of(ipPiece);
-  if (PieceType((move >> 12) & 7) != ipt) return false;                 // pIp field
-
-  const Piece fpPiece = pos.pieceOnSquare(fp);
-  if (fpPiece != NO_PIECE && color_of(fpPiece) == cMy) return false;    // can't capture own
-  if (PieceType((move >> 15) & 7) != type_of(fpPiece)) return false;    // pFp field (NONE on empty / e.p. target)
-
-  const Bitboard ipBit = 1ULL << ip;
-  const Bitboard fpBit = 1ULL << fp;
-  const Bitboard occupied = pos.all();
-  const Square kpos = squareNo(pos.piece<cMy, KING>());
-
-  // --------------------------------------------------------------------- King
-  if (ipt == KING)
-  {
-    const int diff = int(fp) - int(ip);
-
-    if (diff == 2 || diff == -2)                                        // castling
-    {
-      if (meta.checkers != 0) return false;                            // never out of check
-      const Bitboard attacked = meta.enemyAttackedSquares;
-      if (ipBit & attacked) return false;                              // (king-square attacked => in check)
-
-      constexpr int shift = 56 * int(cEmy);
-      if (int(ip) != shift + 4) return false;                          // king must be on its home square
-
-      const Bitboard covered = occupied | attacked;
-      if (diff == 2)                                                   // king side
-      {
-        constexpr int      kingSide = 256 << (2 * int(cMy));
-        constexpr Bitboard rSq      = 96ULL << shift;                  // f1/g1 (or f8/g8)
-        if (!(pos.csep & kingSide)) return false;
-        if (rSq & covered) return false;
-        return true;
-      }
-      // queen side
-      constexpr int      queenSide = 128 << (2 * int(cMy));
-      constexpr Bitboard lMidSq    = 2ULL  << shift;                   // b1 (or b8)
-      constexpr Bitboard lSq       = 12ULL << shift;                   // c1/d1 (or c8/d8)
-      if (!(pos.csep & queenSide)) return false;
-      if (occupied & lMidSq) return false;
-      if (lSq & covered) return false;
-      return true;
-    }
-
-    // ordinary king step
-    if (!(plt::kingMasks[ip] & fpBit)) return false;
-    if (fpBit & meta.enemyAttackedSquares) return false;
-    return true;
-  }
-
-  // any non-king move is impossible under double check
-  if (meta.checkers >= 2) return false;
-
-  // pin ray + (when in check) the squares that block / capture the checker
-  Bitboard pinMask = AllSquares;
-  // Old: pinnedRayDest<cMy>(pos, ip, kpos, pinMask) — 8-direction scan, kept above for reference.
-  const bool pinned = pinnedRayDest_fast<cMy>(pos, ip, kpos, pinMask);  // pinMask unchanged if not pinned
-  const Bitboard checkMask = (meta.checkers == 1) ? meta.legalSquaresMaskInCheck : AllSquares;
-
-  // --------------------------------------------------------------------- Pawn
-  if (ipt == PAWN)
-  {
-    const Square ep = pos.enPassantSquare();
-
-    if (fpBit & plt::pawnCaptureMasks[cMy][ip])                        // diagonal -> capture or e.p.
-    {
-      if (ep != SQUARE_NB && fp == ep)                                // en passant
-      {
-        const Square capSq = fp - pawnPush;                           // the pawn we remove
-        if (pos.pieceOnSquare(capSq) != make_piece(cEmy, PAWN)) return false;
-        if (meta.checkers == 1
-          && !(plt::pawnCaptureMasks[cMy][kpos] & pos.piece<cEmy, PAWN>())) return false;
-        if (!(fpBit & pinMask)) return false;
-        // When the pawn is pinned along its capture diagonal, the pin already
-        // guarantees safety w.r.t. that slider — generation's pinsCheck branch
-        // skips enpassantRecheck for exactly this reason; mirror it here.
-        if (!pinned && !enpassantRecheck<cMy>(ip, pos)) return false;
-        return true;
-      }
-      if (fpPiece == NO_PIECE) return false;                          // nothing there to capture
-      // (enemy colour and pFp already validated above)
-    }
-    else                                                              // straight push
-    {
-      if (fpPiece != NO_PIECE) return false;
-      if (int(fp) == int(ip) + pawnPush)
-        ;                                                             // single push
-      else if (int(fp) == int(ip) + 2 * pawnPush && (ipBit & startRank))
-      {
-        if (pos.pieceOnSquare(Square(int(ip) + pawnPush)) != NO_PIECE) return false;
-      }
-      else return false;
-    }
-
-    if (!(fpBit & checkMask)) return false;
-    if (!(fpBit & pinMask)) return false;
-    return true;
-  }
-
-  // ------------------------------------------------------------------- Knight
-  if (ipt == KNIGHT)
-  {
-    if (!(plt::knightMasks[ip] & fpBit)) return false;
-    if (!(fpBit & checkMask)) return false;
-    if (!(fpBit & pinMask)) return false;                             // a pinned knight can never move
-    return true;
-  }
-
-  // ----------------------------------------------------- Bishop / Rook / Queen
-  Bitboard reachable;
-  if      (ipt == BISHOP) reachable = attackSquares<BISHOP>(ip, occupied);
-  else if (ipt == ROOK  ) reachable = attackSquares<ROOK  >(ip, occupied);
-  else                    reachable = attackSquares<QUEEN >(ip, occupied);
-
-  if (!(reachable & fpBit)) return false;
-  if (!(fpBit & checkMask)) return false;
-  if (!(fpBit & pinMask)) return false;
-  return true;
-}
-
-bool
-isHashMoveLegal(Move move, const ChessBoard& pos, const MoveList& meta)
-{
-  return pos.color == WHITE
-    ? isHashMoveLegalImpl<WHITE>(move, pos, meta)
-    : isHashMoveLegalImpl<BLACK>(move, pos, meta);
-}
-
-#endif
-

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -3,6 +3,7 @@
 #ifndef MOVEGEN_H
 #define MOVEGEN_H
 
+#include <utility>
 #include "bitboard.h"
 #include "lookup_table.h"
 #include "movelist.h"
@@ -29,6 +30,32 @@
 // Checks if move is valid for given position
 bool
 isLegalMoveForPosition(Move move, const ChessBoard& pos);
+
+/**
+ * @brief Cheap legality check for a candidate move (e.g. a transposition-table
+ * best move) against a position whose metadata has already been computed.
+ *
+ * @param move  24-bit packed move (only bits 0..19 — ip/fp/pIp/pFp/promo — are
+ *              consulted; the type/colour/check bits are ignored).
+ * @param pos   the position the move would be played in.
+ * @param meta  a MoveList already filled by stagedGenerateMoves<GEN_METADATA>
+ *              (needs checkers / enemyAttackedSquares / legalSquaresMaskInCheck).
+ *
+ * Deliberately biased toward returning false: a false negative just costs the
+ * caller its fast path, a false positive would feed an illegal move to makeMove.
+ */
+bool
+isHashMoveLegal(Move move, const ChessBoard& pos, const MoveList& meta);
+
+/**
+ * @brief Micro-benchmark hook: times the legacy 8-direction pinnedRayDest vs.
+ * the rayDirection-dispatched pinnedRayDest_fast on every non-king own-side
+ * piece in `pos`, repeated `iters` times. Returns {slow_seconds, fast_seconds}.
+ *
+ * Single-position numbers are noisy; callers should sum across many positions.
+ */
+std::pair<double, double>
+benchmarkPinnedRayDest(const ChessBoard& pos, int iters);
 
 /**
  * @brief Runs one stage of move generation on the given MoveList.

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -31,31 +31,11 @@
 bool
 isLegalMoveForPosition(Move move, const ChessBoard& pos);
 
-/**
- * @brief Cheap legality check for a candidate move (e.g. a transposition-table
- * best move) against a position whose metadata has already been computed.
- *
- * @param move  24-bit packed move (only bits 0..19 — ip/fp/pIp/pFp/promo — are
- *              consulted; the type/colour/check bits are ignored).
- * @param pos   the position the move would be played in.
- * @param meta  a MoveList already filled by stagedGenerateMoves<GEN_METADATA>
- *              (needs checkers / enemyAttackedSquares / legalSquaresMaskInCheck).
- *
- * Deliberately biased toward returning false: a false negative just costs the
- * caller its fast path, a false positive would feed an illegal move to makeMove.
- */
+// Same contract as isLegalMoveForPosition, but skips full move generation:
+// only computes the work needed for the moving piece (geometric reachability
+// + post-move king-safety via super-piece scan from king square).
 bool
-isHashMoveLegal(Move move, const ChessBoard& pos, const MoveList& meta);
-
-/**
- * @brief Micro-benchmark hook: times the legacy 8-direction pinnedRayDest vs.
- * the rayDirection-dispatched pinnedRayDest_fast on every non-king own-side
- * piece in `pos`, repeated `iters` times. Returns {slow_seconds, fast_seconds}.
- *
- * Single-position numbers are noisy; callers should sum across many positions.
- */
-std::pair<double, double>
-benchmarkPinnedRayDest(const ChessBoard& pos, int iters);
+isLegalMoveForPosition_V2(Move move, const ChessBoard& pos);
 
 /**
  * @brief Runs one stage of move generation on the given MoveList.
@@ -77,7 +57,6 @@ stagedGenerateMoves(const ChessBoard& pos, MoveList& myMoves);
  */
 MoveList
 generateMoves(const ChessBoard& pos, bool generateChecksData=false);
-
 
 bool
 pieceTrapped(const ChessBoard& pos, Bitboard myAttackedBB, Bitboard enemyAttackedBB);

--- a/src/movelist.cpp
+++ b/src/movelist.cpp
@@ -493,6 +493,64 @@ MoveList::exists<MType::CHECK>(const ChessBoard& pos) const noexcept
   return false;
 }
 
+void
+MoveList::removeMove(Move m) noexcept
+{
+  const Square fromSq = from_sq(m);
+  const Square toSq   = to_sq(m);
+  const PieceType pt  = PieceType((m >> 12) & 7);
+  const Bitboard fromBit = 1ULL << fromSq;
+  const Bitboard toBit   = 1ULL << toSq;
+
+  if (pt == PAWN)
+  {
+    // En passant: encoded as a capture (bit 20) with captured-piece field
+    // (bits 15..17) == NONE, since fillEnpassantPawns leaves that field zero
+    // (the captured pawn isn't on the destination square).
+    const bool isCapture     = (m >> 20) & 1;
+    const PieceType captured = PieceType((m >> 15) & 7);
+    if (isCapture and captured == NONE)
+    {
+      enpassantPawns &= ~fromBit;
+      return;
+    }
+
+    // Per-square stored pawn (pinned or promoting): the from-square is in
+    // initSquares. Pinned-pawn captures, single/double pushes from a pinned
+    // square, and all promotions land here.
+    if (fromBit & initSquares)
+    {
+      destSquares[fromSq] &= ~toBit;
+      if (destSquares[fromSq] == 0)
+        initSquares &= ~fromBit;
+      return;
+    }
+
+    // Bulk shift-pawn move — identify the bucket from the to-from delta.
+    // Bucket layout (see pawnMovement / fillShiftPawns):
+    //   white (color=1): [0]=+9 (right cap), [1]=+7 (left cap), [2]=+16 (dpush), [3]=+8 (spush)
+    //   black (color=0): [0]=-7,             [1]=-9,            [2]=-16,        [3]=-8
+    const int delta = int(toSq) - int(fromSq);
+    int bucket;
+    switch (delta)
+    {
+      case   9: case  -7: bucket = 0; break;
+      case   7: case  -9: bucket = 1; break;
+      case  16: case -16: bucket = 2; break;
+      case   8: case  -8: bucket = 3; break;
+      default: return; // not a legal pawn delta — silently ignore
+    }
+    pawnDestSquares[bucket] &= ~toBit;
+    return;
+  }
+
+  // Knight, bishop, rook, queen, king (castling included — king's 2-square
+  // hop sits in destSquares[king_sq] like any other king destination).
+  destSquares[fromSq] &= ~toBit;
+  if (destSquares[fromSq] == 0)
+    initSquares &= ~fromBit;
+}
+
 
 template void MoveList::getMoves<MType(1), MType(0)>(const ChessBoard&, MoveArray&) const noexcept;
 template void MoveList::getMoves<MType(1), MType(4)>(const ChessBoard&, MoveArray&) const noexcept;

--- a/src/movelist.cpp
+++ b/src/movelist.cpp
@@ -200,10 +200,24 @@ MoveList::fillPawns(
         }
       }
 
-      movesArray.add(moveQ);
-      movesArray.add(moveR);
-      movesArray.add(moveN);
-      movesArray.add(moveB);
+      // Fast path: no hash-move suppression, or this (from,to) isn't the
+      // suppressed pair — emit all four flavors. promoSuppress == 0 is the
+      // common case; the (from,to) compare alone gates the slow path since
+      // a real promoSuppress always carries non-zero from|to bits.
+      if ((moveB & 0xFFF) != (promoSuppress & 0xFFF))
+      {
+        movesArray.add(moveQ);
+        movesArray.add(moveR);
+        movesArray.add(moveN);
+        movesArray.add(moveB);
+      }
+      else
+      {
+        if ((moveQ & 0xC0FFF) != promoSuppress) movesArray.add(moveQ);
+        if ((moveR & 0xC0FFF) != promoSuppress) movesArray.add(moveR);
+        if ((moveN & 0xC0FFF) != promoSuppress) movesArray.add(moveN);
+        if ((moveB & 0xC0FFF) != promoSuppress) movesArray.add(moveB);
+      }
     }
     else
     {
@@ -240,6 +254,12 @@ MoveList::countMoves() const noexcept
 
   while (mask > 0)
     moveCount += popCount(destSquares[nextSquare(mask)]);
+
+  // Promotion suppression keeps the shared destSquares bit set so the other
+  // three flavors still emit; the pawn-loop above counted all 4, so subtract
+  // the one fillPawns will skip. promoSuppress == 0 means no suppression.
+  if (promoSuppress)
+    moveCount -= 1;
 
   return moveCount;
 }
@@ -504,6 +524,16 @@ MoveList::removeMove(Move m) noexcept
 
   if (pt == PAWN)
   {
+    // Promotion: don't clear the destSquares bit (it's shared by all four
+    // Q/R/N/B flavors). Stash bits 0..11 (from|to) and bits 18..19 (piece)
+    // so fillPawns can skip just the one flavor at emission time.
+    if ((m >> 21) & 1)
+    {
+      promoSuppress = m & 0xC0FFF;
+      ++removedMovesCount;
+      return;
+    }
+
     // En passant: encoded as a capture (bit 20) with captured-piece field
     // (bits 15..17) == NONE, since fillEnpassantPawns leaves that field zero
     // (the captured pawn isn't on the destination square).
@@ -512,17 +542,19 @@ MoveList::removeMove(Move m) noexcept
     if (isCapture and captured == NONE)
     {
       enpassantPawns &= ~fromBit;
+      ++removedMovesCount;
       return;
     }
 
-    // Per-square stored pawn (pinned or promoting): the from-square is in
-    // initSquares. Pinned-pawn captures, single/double pushes from a pinned
-    // square, and all promotions land here.
+    // Per-square stored pawn (pinned): the from-square is in initSquares.
+    // Pinned-pawn captures and single/double pushes from a pinned square
+    // land here. (Promotions handled above.)
     if (fromBit & initSquares)
     {
       destSquares[fromSq] &= ~toBit;
       if (destSquares[fromSq] == 0)
         initSquares &= ~fromBit;
+      ++removedMovesCount;
       return;
     }
 
@@ -541,6 +573,7 @@ MoveList::removeMove(Move m) noexcept
       default: return; // not a legal pawn delta — silently ignore
     }
     pawnDestSquares[bucket] &= ~toBit;
+    ++removedMovesCount;
     return;
   }
 
@@ -549,6 +582,7 @@ MoveList::removeMove(Move m) noexcept
   destSquares[fromSq] &= ~toBit;
   if (destSquares[fromSq] == 0)
     initSquares &= ~fromBit;
+  ++removedMovesCount;
 }
 
 

--- a/src/movelist.h
+++ b/src/movelist.h
@@ -26,6 +26,18 @@ public:
 
   Bitboard enpassantPawns;
 
+  // Single-promo suppression for the hash-move-before-movegen path.
+  // Packs (from | to<<6) in bits 0..11 and the promo-piece encoding in
+  // bits 18..19 (0=B, 1=N, 2=R, 3=Q — same layout as a real Move). Value
+  // 0 (from==to==0 — impossible) means no suppression.
+  Move promoSuppress;
+
+  // Number of times removeMove has been called with effect on this list.
+  // Used as the moveNo bias inside playSubsetMoves so LMR's `moveNo <
+  // LMR_LIMIT` gate accounts for moves searched outside the playAllMoves
+  // loop (i.e. the hash-move fast path).
+  uint16_t removedMovesCount;
+
   // Array to store squares that give check to the enemy king
   // {Pawn, Bishop, Knight, Rook, Queen}
   // Index 1: Squares where a bishop can give check to the enemy king
@@ -49,10 +61,15 @@ public:
   Bitboard enemyAttackedSquares;
 
   MoveList()
-  : checkers(0), initSquares(0), enpassantPawns(0) {}
+  : checkers(0), initSquares(0), enpassantPawns(0),
+    promoSuppress(0), removedMovesCount(0) {}
 
   MoveList(Color c)
-  : color(c), checkers(0), initSquares(0), enpassantPawns(0) {}
+  : color(c), checkers(0), initSquares(0), enpassantPawns(0),
+    promoSuppress(0), removedMovesCount(0) {}
+
+  size_t
+  removedMoves() const noexcept { return removedMovesCount; }
 
   void
   add(Square sq, Bitboard _destSquares)
@@ -88,10 +105,10 @@ public:
   // skip it. Used by the hash-move-before-movegen path to drop the already-
   // searched hash move without a post-hoc swap+popBack on MoveArray.
   //
-  // Caveat: for promotions, all four flavors (Q/R/B/N) share one destSquares
-  // bit, so removing a promotion drops every flavor to that target. Acceptable
-  // since the hash move is the best candidate at this node; underpromotions
-  // are searched at children via different paths.
+  // Promotions: all four flavors (Q/R/B/N) share one destSquares bit, so we
+  // can't clear the bit without dropping the other three legitimate flavors.
+  // Instead, stash (from,to)+piece into promoSuppress; fillPawns skips that
+  // one flavor at emission time.
   void
   removeMove(Move m) noexcept;
 

--- a/src/movelist.h
+++ b/src/movelist.h
@@ -84,6 +84,17 @@ public:
   bool
   exists(const ChessBoard& pos) const noexcept;
 
+  // Remove a single move from the MoveList so subsequent getMoves<>() calls
+  // skip it. Used by the hash-move-before-movegen path to drop the already-
+  // searched hash move without a post-hoc swap+popBack on MoveArray.
+  //
+  // Caveat: for promotions, all four flavors (Q/R/B/N) share one destSquares
+  // bit, so removing a promotion drops every flavor to that target. Acceptable
+  // since the hash move is the best candidate at this node; underpromotions
+  // are searched at children via different paths.
+  void
+  removeMove(Move m) noexcept;
+
 private:
   template <MType mt1, MType mt2>
   void

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,10 +26,23 @@ prioritizeMoves(MoveArray& movesArray, size_t start)
 }
 
 size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, size_t start)
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, size_t start, Move hashMove)
 {
   const auto seeComparator = [&pos] (Move move1, Move move2)
   { return seeScore(pos, move1) > seeScore(pos, move2); };
+
+  // Hash move first — match by filter() (low 23 bits) since the CHECK bit
+  // (bit 23) may differ between the stored move and the freshly-generated one.
+  if (hasFlag(mTypes, MType::HASH_MOVE) and hashMove != NULL_MOVE)
+  {
+    Move target = filter(hashMove);
+    for (size_t i = start; i < movesArray.size(); i++) {
+      if (filter(movesArray[i]) == target) {
+        std::swap(movesArray[i], movesArray[start++]);
+        break;
+      }
+    }
+  }
 
   size_t prevS = start;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,23 +26,10 @@ prioritizeMoves(MoveArray& movesArray, size_t start)
 }
 
 size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, size_t start, Move hashMove)
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, size_t start)
 {
   const auto seeComparator = [&pos] (Move move1, Move move2)
   { return seeScore(pos, move1) > seeScore(pos, move2); };
-
-  // Hash move first — match by filter() (low 23 bits) since the CHECK bit
-  // (bit 23) may differ between the stored move and the freshly-generated one.
-  if (hasFlag(mTypes, MType::HASH_MOVE) and hashMove != NULL_MOVE)
-  {
-    Move target = filter(hashMove);
-    for (size_t i = start; i < movesArray.size(); i++) {
-      if (filter(movesArray[i]) == target) {
-        std::swap(movesArray[i], movesArray[start++]);
-        break;
-      }
-    }
-  }
 
   size_t prevS = start;
 

--- a/src/search.h
+++ b/src/search.h
@@ -330,7 +330,7 @@ class SearchData
 };
 
 size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply, size_t start = 0, Move hashMove = NULL_MOVE);
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply, size_t start = 0);
 
 Score
 seeScore(const ChessBoard& pos, Move move);

--- a/src/search.h
+++ b/src/search.h
@@ -91,6 +91,22 @@ class SearchData
   // Time spend on searching for move in position (in secs.)
   double timeForSearch = 0;
 
+  public:
+
+  // Transposition-table instrumentation, accumulated over the whole search:
+  //   ttProbes   — nodes that probed the TT
+  //   ttHits     — of those, the position was found (hash match)
+  //   ttCutoffs  — of those hits, the entry was deep enough to return a bound
+  uint64_t ttProbes = 0, ttHits = 0, ttCutoffs = 0;
+
+  // Hash-move (TT best move) instrumentation, accumulated over the whole search:
+  //   ttMoveProvided   — nodes where the TT handed back a usable best move
+  //   hashMoveInList   — of those, the move was legal here and tried first
+  //   hashMoveCutoffs  — of those, the hash move alone produced a beta cutoff
+  uint64_t ttMoveProvided = 0, hashMoveInList = 0, hashMoveCutoffs = 0;
+
+  private:
+
   Varray<Move, MAX_PLY> pvLine;
 
   // Stores the <best_move, eval> for each depth during search.

--- a/src/search.h
+++ b/src/search.h
@@ -314,7 +314,7 @@ class SearchData
 };
 
 size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply, size_t start = 0);
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply, size_t start = 0, Move hashMove = NULL_MOVE);
 
 Score
 seeScore(const ChessBoard& pos, Move move);

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -38,7 +38,7 @@ quiescenceSearch(ChessBoard& pos, Score alpha, Score beta, Ply ply, int pvIndex)
 
   const MoveList myMoves = generateMoves(pos);
 
-  if (myMoves.countMoves() == 0)
+  if (!myMoves.anyMove())
     return myMoves.checkers ? checkmateScore(ply) : VALUE_ZERO;
 
   if (!myMoves.exists<MType::CAPTURES>(pos) and isTheoreticalDraw(pos))
@@ -197,46 +197,25 @@ playAllMoves(
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf, Move& bestMoveOut, Move hashMove
+  Flag& hashf, Move& bestMoveOut
 )
 {
-  // Set pvArray, for storing the search_tree
   if constexpr (moveGen == 0)
-  {
-    pvArray[pvIndex] = NULL_MOVE;
-
-    // If a hash move is the lead stage, materialize all moves up-front so
-    // a quiet hash move can be matched before the staged QUIET phase.
-    // Otherwise stick with captures-first staging.
-    if constexpr (orderType == MType::HASH_MOVE)
-      myMoves.getMoves<MType::CAPTURES | MType::QUIET, MType::CHECK>(pos, movesArray);
-    else
-      myMoves.getMoves<MType::CAPTURES>(pos, movesArray);
-  }
+    myMoves.getMoves<MType::CAPTURES>(pos, movesArray);
 
   if constexpr (moveGen == 1)
-  {
-    if constexpr (orderType != MType::CAPTURES)
-      myMoves.getMoves<MType::QUIET, MType::CHECK>(pos, movesArray);
-  }
+    myMoves.getMoves<MType::QUIET, MType::CHECK>(pos, movesArray);
 
-  size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start, hashMove);
-
-  if constexpr (orderType == MType::HASH_MOVE)
-    if (end > start) info.hashMoveInList++;
+  size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start);
 
   playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 
   if (hashf == Flag::HASH_BETA)
-  {
-    if constexpr (orderType == MType::HASH_MOVE)
-      info.hashMoveCutoffs++;
     return;
-  }
 
   if constexpr (sizeof...(rest) > 0)
     playAllMoves<moveGen + 1, rest...>
-      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, hashMove);
+      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 }
 
 Score
@@ -249,24 +228,15 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   if (depth <= 0)
     return quiescenceSearch<1>(pos, alpha, beta, ply, pvIndex);
 
-  // Generate moves for current board position
-  MoveList myMoves = generateMoves(pos, true);
-
-  if (myMoves.countMoves() == 0)
-    return myMoves.checkers ? checkmateScore(ply) : VALUE_ZERO;
-
-  if (pos.threeMoveRepetition()
-   or pos.fiftyMoveDraw()
-   or (!myMoves.exists<MType::CAPTURES>(pos) and isTheoreticalDraw(pos))
-  ) return VALUE_DRAW;
+  // Cheap repetition / 50-move draws — no movegen needed.
+  if (pos.threeMoveRepetition() or pos.fiftyMoveDraw())
+    return VALUE_DRAW;
 
   info.addNode();
 
   Move hashMove = NULL_MOVE;
 
   if constexpr (USE_TT) {
-    // TT_lookup (Check if given board is already in transpostion table)
-    // check/stale-mate check needed before TT_lookup, else can lead to search failures.
     bool ttHit = false;
     Score ttValue = tt.lookupPosition(pos.hashValue, depth, alpha, beta, hashMove, ttHit);
 
@@ -282,17 +252,81 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
       info.ttMoveProvided++;
   }
 
+  // Movegen: GEN_METADATA + GEN_MOVES first so the extension policy
+  // (countMoves), terminal/draw checks, and theoretical-draw recognizer all
+  // see complete data. GEN_CHECKS is deferred — it's only needed for
+  // MType::CHECK ordering inside playAllMoves, so a hash-move beta cutoff
+  // skips it (and all of orderMoves/staging) entirely.
+  MoveList myMoves;
+  stagedGenerateMoves<GEN_METADATA>(pos, myMoves);
+  stagedGenerateMoves<GEN_MOVES   >(pos, myMoves);
+
+  if (!myMoves.anyMove())
+    return myMoves.checkers ? checkmateScore(ply) : VALUE_ZERO;
+
+  if (!myMoves.exists<MType::CAPTURES>(pos) and isTheoreticalDraw(pos))
+    return VALUE_DRAW;
+
   if constexpr (USE_EXTENSIONS) {
     int extensions = searchExtension(pos, myMoves, numExtensions, depth);
     depth += extensions;
     numExtensions += extensions;
   }
 
+  int pvNextIndex = pvIndex + MAX_PLY - ply;
+  pvArray[pvIndex] = NULL_MOVE;
+
   Flag hashf = Flag::HASH_ALPHA;
   Move bestMoveOut = NULL_MOVE;
+  bool hashMovePlayed = false;
+
+  // Hash-move-before-ordering attempt: if the TT handed back a move and V2
+  // says it's legal here, search it first at the *boosted* depth and
+  // numExtensions, so it gets the same effective ply budget as every other
+  // move at this node. A beta cutoff returns without ever running GEN_CHECKS
+  // or orderMoves.
+  if (hashMove != NULL_MOVE and isLegalMoveForPosition_V2(hashMove, pos))
+  {
+    info.hashMoveInList++;
+    hashMovePlayed = true;
+
+    pos.makeMove(hashMove);
+    Score eval = -alphaBeta(pos, depth - 1, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
+    pos.unmakeMove();
+
+    if (info.timeOver())
+      return TIMEOUT;
+
+    if (eval >= beta)
+    {
+      info.hashMoveCutoffs++;
+      if constexpr (USE_TT)
+        tt.recordPosition(pos.hashValue, depth, beta, Flag::HASH_BETA, filter(hashMove));
+      return beta;
+    }
+
+    bestMoveOut = filter(hashMove);
+    if (eval > alpha)
+    {
+      hashf = Flag::HASH_EXACT;
+      alpha = eval;
+      pvArray[pvIndex] = filter(hashMove);
+      movcpy(pvArray + pvIndex + 1, pvArray + pvNextIndex, MAX_PLY - ply - 1);
+    }
+  }
+
+  // Need check-giving-square data for MType::CHECK ordering downstream.
+  stagedGenerateMoves<GEN_CHECKS>(pos, myMoves);
+
+  // Drop the already-searched hash move so subsequent getMoves<>() calls in
+  // playAllMoves don't re-emit it. Both branches now feed the same uniform
+  // playAllMoves<0, …> entry.
+  if (hashMovePlayed)
+    myMoves.removeMove(hashMove);
+
   MoveArray movesArray;
-  playAllMoves<0, MType::HASH_MOVE, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
-    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, hashMove);
+  playAllMoves<0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
+    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 
   if constexpr (USE_TT) {
     tt.recordPosition(pos.hashValue, depth, alpha, hashf, bestMoveOut);
@@ -344,7 +378,7 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
   resetPvLine();
   clearKillers();
 
-  if (generateMoves(board).countMoves() == 0)
+  if (!generateMoves(board).anyMove())
   {
     writer << "Position has no legal moves! Discarding Search." << endl;
     return;

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -145,7 +145,8 @@ playSubsetMoves(
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf, Move& bestMoveOut
+  Flag& hashf, Move& bestMoveOut,
+  size_t moveNoBias = 0
 )
 {
   int pvNextIndex = pvIndex + MAX_PLY - ply;
@@ -159,7 +160,12 @@ playSubsetMoves(
     if (bestMoveOut == NULL_MOVE)
       bestMoveOut = filter(move);
 
-    Score eval = playMove<reduction>(pos, move, moveNo, depth, alpha, beta, ply, pvNextIndex, numExtensions);
+    // moveNoBias accounts for moves searched *outside* this array (the
+    // hash-move fast-path searches 1 move before playAllMoves runs). Without
+    // this, LMR's `moveNo < LMR_LIMIT` gate gives the first staged move an
+    // extra full-depth search the old impl wouldn't have done — that's where
+    // the ~25% tree-bloat was coming from.
+    Score eval = playMove<reduction>(pos, move, moveNo + moveNoBias, depth, alpha, beta, ply, pvNextIndex, numExtensions);
 
     // No time left!
     if (info.timeOver())
@@ -197,7 +203,8 @@ playAllMoves(
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf, Move& bestMoveOut
+  Flag& hashf, Move& bestMoveOut,
+  size_t moveNoBias
 )
 {
   if constexpr (moveGen == 0)
@@ -208,14 +215,14 @@ playAllMoves(
 
   size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start);
 
-  playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
+  playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, moveNoBias);
 
   if (hashf == Flag::HASH_BETA)
     return;
 
   if constexpr (sizeof...(rest) > 0)
     playAllMoves<moveGen + 1, rest...>
-      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
+      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, moveNoBias);
 }
 
 Score
@@ -324,9 +331,13 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   if (hashMovePlayed)
     myMoves.removeMove(hashMove);
 
+  // Bias subsequent moveNo by 1 when the hash-move fast-path already searched
+  // one move — keeps the LMR_LIMIT gate behaving identically to the old impl
+  // where the hash move occupied movesArray[0].
+  size_t moveNoBias = hashMovePlayed ? 1 : 0;
   MoveArray movesArray;
   playAllMoves<0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
-    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
+    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, moveNoBias);
 
   if constexpr (USE_TT) {
     tt.recordPosition(pos.hashValue, depth, alpha, hashf, bestMoveOut);

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -221,10 +221,18 @@ playAllMoves(
   }
 
   size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start, hashMove);
+
+  if constexpr (orderType == MType::HASH_MOVE)
+    if (end > start) info.hashMoveInList++;
+
   playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 
   if (hashf == Flag::HASH_BETA)
+  {
+    if constexpr (orderType == MType::HASH_MOVE)
+      info.hashMoveCutoffs++;
     return;
+  }
 
   if constexpr (sizeof...(rest) > 0)
     playAllMoves<moveGen + 1, rest...>
@@ -247,8 +255,10 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   if (myMoves.countMoves() == 0)
     return myMoves.checkers ? checkmateScore(ply) : VALUE_ZERO;
 
-  if (pos.threeMoveRepetition() or pos.fiftyMoveDraw() or (!myMoves.exists<MType::CAPTURES>(pos) and isTheoreticalDraw(pos)))
-    return VALUE_DRAW;
+  if (pos.threeMoveRepetition()
+   or pos.fiftyMoveDraw()
+   or (!myMoves.exists<MType::CAPTURES>(pos) and isTheoreticalDraw(pos))
+  ) return VALUE_DRAW;
 
   info.addNode();
 
@@ -257,10 +267,19 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   if constexpr (USE_TT) {
     // TT_lookup (Check if given board is already in transpostion table)
     // check/stale-mate check needed before TT_lookup, else can lead to search failures.
-    Score ttValue = tt.lookupPosition(pos.hashValue, depth, alpha, beta, hashMove);
+    bool ttHit = false;
+    Score ttValue = tt.lookupPosition(pos.hashValue, depth, alpha, beta, hashMove, ttHit);
 
-    if (ttValue != VALUE_UNKNOWN)
+    info.ttProbes++;
+    if (ttHit) info.ttHits++;
+
+    if (ttValue != VALUE_UNKNOWN) {
+      info.ttCutoffs++;
       return ttValue;
+    }
+
+    if (hashMove != NULL_MOVE)
+      info.ttMoveProvided++;
   }
 
   if constexpr (USE_EXTENSIONS) {
@@ -398,5 +417,22 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
 
   info.searchCompleted();
   if (debug)
+  {
+    double hitRate = info.ttProbes
+      ? 100.0 * double(info.ttHits) / double(info.ttProbes) : 0.0;
+    double ttCutRate = info.ttHits
+      ? 100.0 * double(info.ttCutoffs) / double(info.ttHits) : 0.0;
+    writer << "TT: probes=" << info.ttProbes
+           << " hits=" << info.ttHits << " (" << std::fixed << std::setprecision(1) << hitRate << "%)"
+           << " cutoffs=" << info.ttCutoffs << " (" << ttCutRate << "% of hits)" << endl;
+
+    double cutoffRate = info.hashMoveInList
+      ? 100.0 * double(info.hashMoveCutoffs) / double(info.hashMoveInList) : 0.0;
+    double availRate = info.ttMoveProvided
+      ? 100.0 * double(info.hashMoveInList) / double(info.ttMoveProvided) : 0.0;
+    writer << "Hash move: ttProvided=" << info.ttMoveProvided
+           << " inList=" << info.hashMoveInList << " (" << std::fixed << std::setprecision(1) << availRate << "%)"
+           << " cutoffs=" << info.hashMoveCutoffs << " (" << cutoffRate << "% of inList)" << endl;
     writer << "Search Done!" << endl;
+  }
 }

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -140,16 +140,22 @@ playMove(ChessBoard& pos, Move move, size_t moveNo,
 
 static void
 playSubsetMoves(
-  ChessBoard& pos, MoveArray& movesArray,
+  ChessBoard& pos, const MoveList& myMoves, MoveArray& movesArray,
   size_t start, size_t end,
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf, Move& bestMoveOut,
-  size_t moveNoBias = 0
+  Flag& hashf, Move& bestMoveOut
 )
 {
   int pvNextIndex = pvIndex + MAX_PLY - ply;
+
+  // myMoves.removedMoves() accounts for moves searched *outside* this array
+  // (the hash-move fast-path searches 1 move before playAllMoves runs).
+  // Without this, LMR's `moveNo < LMR_LIMIT` gate gives the first staged
+  // move an extra full-depth search the old impl wouldn't have done —
+  // that's where the ~25% tree-bloat was coming from.
+  const size_t moveNoBias = myMoves.removedMoves();
 
   for (size_t moveNo = start; moveNo < end; ++moveNo)
   {
@@ -160,11 +166,6 @@ playSubsetMoves(
     if (bestMoveOut == NULL_MOVE)
       bestMoveOut = filter(move);
 
-    // moveNoBias accounts for moves searched *outside* this array (the
-    // hash-move fast-path searches 1 move before playAllMoves runs). Without
-    // this, LMR's `moveNo < LMR_LIMIT` gate gives the first staged move an
-    // extra full-depth search the old impl wouldn't have done — that's where
-    // the ~25% tree-bloat was coming from.
     Score eval = playMove<reduction>(pos, move, moveNo + moveNoBias, depth, alpha, beta, ply, pvNextIndex, numExtensions);
 
     // No time left!
@@ -203,8 +204,7 @@ playAllMoves(
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf, Move& bestMoveOut,
-  size_t moveNoBias
+  Flag& hashf, Move& bestMoveOut
 )
 {
   if constexpr (moveGen == 0)
@@ -215,14 +215,14 @@ playAllMoves(
 
   size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start);
 
-  playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, moveNoBias);
+  playSubsetMoves(pos, myMoves, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 
   if (hashf == Flag::HASH_BETA)
     return;
 
   if constexpr (sizeof...(rest) > 0)
     playAllMoves<moveGen + 1, rest...>
-      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, moveNoBias);
+      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 }
 
 Score
@@ -331,13 +331,12 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   if (hashMovePlayed)
     myMoves.removeMove(hashMove);
 
-  // Bias subsequent moveNo by 1 when the hash-move fast-path already searched
-  // one move — keeps the LMR_LIMIT gate behaving identically to the old impl
-  // where the hash move occupied movesArray[0].
-  size_t moveNoBias = hashMovePlayed ? 1 : 0;
+  // LMR bias is now derived from myMoves.removedMoves() inside
+  // playSubsetMoves — the hash-move fast-path's removeMove() call already
+  // bumped that counter, so the LMR_LIMIT gate sees the right moveNo.
   MoveArray movesArray;
   playAllMoves<0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
-    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, moveNoBias);
+    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 
   if constexpr (USE_TT) {
     tt.recordPosition(pos.hashValue, depth, alpha, hashf, bestMoveOut);

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -145,7 +145,7 @@ playSubsetMoves(
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf
+  Flag& hashf, Move& bestMoveOut
 )
 {
   int pvNextIndex = pvIndex + MAX_PLY - ply;
@@ -153,6 +153,12 @@ playSubsetMoves(
   for (size_t moveNo = start; moveNo < end; ++moveNo)
   {
     Move move = movesArray[moveNo];
+
+    // HASH_ALPHA fallback: remember the first searched move at this node so
+    // the TT entry has *something* to suggest on a fail-low revisit.
+    if (bestMoveOut == NULL_MOVE)
+      bestMoveOut = filter(move);
+
     Score eval = playMove<reduction>(pos, move, moveNo, depth, alpha, beta, ply, pvNextIndex, numExtensions);
 
     // No time left!
@@ -165,6 +171,7 @@ playSubsetMoves(
     {
       hashf = Flag::HASH_BETA;
       alpha = beta;
+      bestMoveOut = filter(move);
 
       if (is_type<MType::QUIET>(move))
         killerMoves[ply].addKillerMove(move);
@@ -174,6 +181,7 @@ playSubsetMoves(
     // Better move found, update the result
     if (eval > alpha) {
       hashf = Flag::HASH_EXACT, alpha = eval;
+      bestMoveOut = filter(move);
       pvArray[pvIndex] = filter(move);
       movcpy (pvArray + pvIndex + 1,
               pvArray + pvNextIndex, MAX_PLY - ply - 1);
@@ -189,28 +197,38 @@ playAllMoves(
   Score& alpha, Score& beta,
   Depth depth, Ply ply,
   int pvIndex, int numExtensions,
-  Flag& hashf
+  Flag& hashf, Move& bestMoveOut, Move hashMove
 )
 {
   // Set pvArray, for storing the search_tree
   if constexpr (moveGen == 0)
   {
     pvArray[pvIndex] = NULL_MOVE;
-    myMoves.getMoves<MType::CAPTURES>(pos, movesArray);
+
+    // If a hash move is the lead stage, materialize all moves up-front so
+    // a quiet hash move can be matched before the staged QUIET phase.
+    // Otherwise stick with captures-first staging.
+    if constexpr (orderType == MType::HASH_MOVE)
+      myMoves.getMoves<MType::CAPTURES | MType::QUIET, MType::CHECK>(pos, movesArray);
+    else
+      myMoves.getMoves<MType::CAPTURES>(pos, movesArray);
   }
 
   if constexpr (moveGen == 1)
-    myMoves.getMoves<MType::QUIET, MType::CHECK>(pos, movesArray);
+  {
+    if constexpr (orderType != MType::CAPTURES)
+      myMoves.getMoves<MType::QUIET, MType::CHECK>(pos, movesArray);
+  }
 
-  size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start);
-  playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf);
+  size_t end = orderType == MType::QUIET ? movesArray.size() : orderMoves(pos, movesArray, orderType, ply, start, hashMove);
+  playSubsetMoves(pos, movesArray, start, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut);
 
   if (hashf == Flag::HASH_BETA)
     return;
 
   if constexpr (sizeof...(rest) > 0)
     playAllMoves<moveGen + 1, rest...>
-      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf);
+      (pos, myMoves, movesArray, end, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, hashMove);
 }
 
 Score
@@ -234,10 +252,12 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
 
   info.addNode();
 
+  Move hashMove = NULL_MOVE;
+
   if constexpr (USE_TT) {
     // TT_lookup (Check if given board is already in transpostion table)
     // check/stale-mate check needed before TT_lookup, else can lead to search failures.
-    Score ttValue = tt.lookupPosition(pos.hashValue, depth, alpha, beta);
+    Score ttValue = tt.lookupPosition(pos.hashValue, depth, alpha, beta, hashMove);
 
     if (ttValue != VALUE_UNKNOWN)
       return ttValue;
@@ -250,12 +270,13 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   }
 
   Flag hashf = Flag::HASH_ALPHA;
+  Move bestMoveOut = NULL_MOVE;
   MoveArray movesArray;
-  playAllMoves<0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
-    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf);
+  playAllMoves<0, MType::HASH_MOVE, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
+    (pos, myMoves, movesArray, 0, alpha, beta, depth, ply, pvIndex, numExtensions, hashf, bestMoveOut, hashMove);
 
   if constexpr (USE_TT) {
-    tt.recordPosition(pos.hashValue, depth, alpha, hashf);
+    tt.recordPosition(pos.hashValue, depth, alpha, hashf, bestMoveOut);
   }
 
   return alpha;

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -1,6 +1,7 @@
 
 #include <unordered_map>
 #include <functional>
+#include <set>
 #include "task.h"
 #include "search.h"
 #include "single_thread.h"
@@ -121,7 +122,242 @@ accuracyTest()
 }
 
 static void
-helper() 
+hashLegalTest()
+{
+  // Argument : elsa hashlegal
+  //
+  // Equivalence / fuzz test for isHashMoveLegal(). For each position in the
+  // suite below we build the reference set of legal moves (keyed on the 20 bits
+  // isHashMoveLegal actually consults — ip/fp/pIp/pFp/promo) and then check:
+  //   * every legal move is accepted              (no false negatives)
+  //   * no other move is accepted                 (no false positives)
+  //   * anything accepted survives a makeMove / integrityCheck / unmakeMove
+  //
+  // Run this before wiring isHashMoveLegal into the search.
+
+  // ---- gather FENs: the perft suites + a hand-picked set of delicate cases ----
+  std::vector<std::string> fens;
+
+  const auto addPerftSuite = [&] (const std::vector<std::string>& suite)
+  {
+    for (const auto& entry : suite)
+      fens.push_back(utils::strip(utils::split(entry, '|').front()));
+  };
+  addPerftSuite(test_data::accuracy::suite1);
+  addPerftSuite(test_data::speed::suite1);
+
+  const std::vector<std::string> tricky = {
+    "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",                      // castling: all four sides free
+    "r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 0 1",
+    "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+    "4k3/8/8/8/8/8/4r3/R3K2R w KQ - 0 1",                        // white in check on the e-file -> no castling
+    "r3k2r/8/8/8/8/5b2/8/R3K2R w KQkq - 0 1",                    // f3 bishop attacks g2/h1... and the queenside path
+    "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3",   // e.p. available (exd6)
+    "4k3/8/8/2Pp4/8/8/8/4K3 w - d6 0 1",                         // plain e.p.
+    "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",                 // famous e.p. discovered-check setup
+    "8/8/3p4/KPp4r/1R3p1k/8/4P1P1/8 w - c6 0 1",                 // ...with the e.p. square actually set
+    "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", // d7 pawn: push-promo + capture-promos
+    "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1",                   // a mess of promotions and capture-promotions
+    "rnbqkbnr/1ppppppp/p7/8/Q7/8/PPPPPPPP/RNB1KBNR b KQkq - 1 2",// black in check from Qa4 -> block / capture / Kd... no
+    "8/8/8/3k4/3Pp3/8/8/3KR3 b - d3 0 1",                        // pinned-ish pawn + e.p. interplay
+    "4k3/8/8/8/8/8/3p4/4K3 b - - 0 1",                           // black pawn one step from promotion, blocked path
+    "rnb1kbnr/pp1ppppp/8/q1p5/8/2P5/PP1PPPPP/RNBQKBNR w KQkq - 1 3",  // Qa5 pins... actually checks? no — diag to e1? no
+    "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", // dense, pins galore, a7 push-promos
+    "8/8/8/8/k2Pp2Q/8/8/4K3 b - d3 0 1",                         // black e4 pawn pinned by Qh4 along the 4th rank
+    "8/8/8/8/k1pP3R/8/8/4K3 b - d3 0 1",                         // e.p. capture by c4 would expose Rh4 -> illegal
+    START_FEN,
+  };
+  for (const auto& fen : tricky)
+    fens.push_back(fen);
+
+  // ---- simple deterministic PRNG for fuzzed candidates ----
+  uint64_t rngState = 0x9E3779B97F4A7C15ULL;
+  const auto nextRand = [&] () -> uint64_t
+  {
+    rngState ^= rngState << 13;
+    rngState ^= rngState >> 7;
+    rngState ^= rngState << 17;
+    return rngState;
+  };
+
+  size_t  posCount = 0;
+  size_t  refMoveTotal = 0;
+  size_t  candidatesChecked = 0;
+  size_t  falseNegatives = 0;
+  size_t  falsePositives = 0;
+  size_t  corruptions = 0;
+
+  // Canonical identity of a move under makeMove semantics: ip|fp|pIp|pFp, plus
+  // the promotion piece *only* when the destination is the promotion rank
+  // (otherwise makeMove — and isHashMoveLegal — never look at those two bits).
+  const auto canonKey = [] (Move m) -> Move
+  {
+    Move k = m & 0x3FFFF;
+    if (((m >> 12) & 7) == PAWN && ((1ULL << to_sq(m)) & Rank18))
+      k |= m & 0xC0000;
+    return k;
+  };
+
+  const auto reportFail = [] (const char* what, const std::string& fen, Move m)
+  {
+    cout << "  [FAIL] " << what
+         << "  fen = " << fen
+         << "  move = 0x" << std::hex << m << std::dec
+         << "  (" << char('a' + (m & 7)) << char('1' + ((m >> 3) & 7))
+         << char('a' + ((m >> 6) & 7)) << char('1' + ((m >> 9) & 7)) << ")\n";
+  };
+
+  for (const auto& fen : fens)
+  {
+    ChessBoard pos(fen);
+    ++posCount;
+
+    MoveList meta;
+    stagedGenerateMoves<GEN_METADATA>(pos, meta);
+
+    MoveList full = generateMoves(pos);
+    MoveArray legalMoves;
+    full.getMoves(pos, legalMoves);
+
+    std::set<Move> ref;
+    for (const Move m : legalMoves)
+      ref.insert(canonKey(m));
+    refMoveTotal += ref.size();
+
+    // ---- (a) no false negatives: every generated legal move must be accepted ----
+    for (const Move m : legalMoves)
+    {
+      ++candidatesChecked;
+      if (!isHashMoveLegal(m, pos, meta))
+      {
+        ++falseNegatives;
+        reportFail("false negative (legal move rejected)", fen, m);
+      }
+    }
+
+    const auto vet = [&] (Move c)
+    {
+      ++candidatesChecked;
+      if (!isHashMoveLegal(c, pos, meta))
+        return;
+      if (ref.find(canonKey(c)) == ref.end())
+      {
+        ++falsePositives;
+        reportFail("false positive (illegal move accepted)", fen, c);
+        return;
+      }
+      // accepted *and* genuinely legal — confirm makeMove keeps the board sane
+      pos.makeMove(c);
+      const bool ok = pos.integrityCheck() && (pos.hashValue == pos.generateHashkey());
+      pos.unmakeMove();
+      if (!ok)
+      {
+        ++corruptions;
+        reportFail("makeMove corrupted the board", fen, c);
+      }
+    };
+
+    // ---- (b) structured sweep: every (ip, fp) starting from one of our pieces,
+    //          correct pIp/pFp, and (for pawns) every promotion piece ----
+    Move colorBit = Move(pos.color) << 22;
+    for (int ipi = 0; ipi < SQUARE_NB; ++ipi)
+    {
+      Piece ipPiece = pos.pieceOnSquare(Square(ipi));
+      if (ipPiece == NO_PIECE || color_of(ipPiece) != pos.color)
+        continue;
+      PieceType ipt = type_of(ipPiece);
+
+      for (int fpi = 0; fpi < SQUARE_NB; ++fpi)
+      {
+        if (fpi == ipi) continue;
+        PieceType fpt = type_of(pos.pieceOnSquare(Square(fpi)));
+        Move base = colorBit | (Move(ipt) << 12) | (Move(fpt) << 15)
+                  | (Move(fpi) << 6) | Move(ipi);
+
+        if (ipt == PAWN)
+          for (Move promo = 0; promo < 4; ++promo)
+            vet(base | (promo << 18));
+        else
+          vet(base);
+
+        // a couple of deliberately-corrupt encodings (wrong pIp / pFp)
+        vet((base & ~(Move(7) << 12)) | (Move((ipt % 6) + 1) << 12));
+        vet((base & ~(Move(7) << 15)) | (Move((fpt + 1) & 7) << 15));
+      }
+    }
+
+    // ---- (c) near-misses of real legal moves: tweak one field by a little ----
+    for (const Move m : legalMoves)
+    {
+      vet(m ^ Move(1));                       // ip +/- 1
+      vet(m ^ (Move(1) << 6));                // fp +/- 1
+      vet(m ^ (Move(1) << 12));               // flip a pIp bit
+      vet(m ^ (Move(1) << 15));               // flip a pFp bit
+      vet(m ^ (Move(3) << 18));               // flip promo bits
+      vet(m ^ (Move(7) << 6));                // fp jumped by 7
+    }
+
+    // ---- (d) pure random 24-bit patterns ----
+    for (int i = 0; i < 4000; ++i)
+      vet(Move(nextRand() & 0xFFFFFF));
+  }
+
+  cout << "\nisHashMoveLegal fuzz test\n"
+       << "  positions          : " << posCount << '\n'
+       << "  legal moves (uniq) : " << refMoveTotal << '\n'
+       << "  candidates checked : " << candidatesChecked << '\n'
+       << "  false negatives    : " << falseNegatives << '\n'
+       << "  false positives    : " << falsePositives << '\n'
+       << "  board corruptions  : " << corruptions << '\n';
+
+  if (falseNegatives == 0 && falsePositives == 0 && corruptions == 0)
+    cout << "  RESULT             : PASS\n" << std::flush;
+  else
+    cout << "  RESULT             : FAIL\n" << std::flush;
+
+  // ---- micro-benchmark: pinnedRayDest (8-dir scan) vs pinnedRayDest_fast ----
+  // Same FEN list, every non-king own-side piece, kIters per position. The two
+  // functions are timed back-to-back inside benchmarkPinnedRayDest; we sum
+  // across positions to drown out single-call noise. Run a warm-up pass first.
+  constexpr int kIters = 20000;
+
+  double slowTotal = 0.0, fastTotal = 0.0;
+  size_t pieceCallTotal = 0;
+
+  for (const auto& fen : fens)
+  {
+    ChessBoard pos(fen);
+    benchmarkPinnedRayDest(pos, 200);                 // warm-up, discarded
+    const auto [slow, fast] = benchmarkPinnedRayDest(pos, kIters);
+    slowTotal += slow;
+    fastTotal += fast;
+
+    const Bitboard sideMask = (pos.color == WHITE)
+      ? (pos.piece<WHITE, PAWN>()  | pos.piece<WHITE, BISHOP>()
+       | pos.piece<WHITE, KNIGHT>()| pos.piece<WHITE, ROOK>()
+       | pos.piece<WHITE, QUEEN>())
+      : (pos.piece<BLACK, PAWN>()  | pos.piece<BLACK, BISHOP>()
+       | pos.piece<BLACK, KNIGHT>()| pos.piece<BLACK, ROOK>()
+       | pos.piece<BLACK, QUEEN>());
+    pieceCallTotal += size_t(__builtin_popcountll(sideMask)) * size_t(kIters);
+  }
+
+  const double slowNs = slowTotal * 1e9 / double(pieceCallTotal);
+  const double fastNs = fastTotal * 1e9 / double(pieceCallTotal);
+  const double speedup = (fastTotal > 0.0) ? (slowTotal / fastTotal) : 0.0;
+
+  cout << "\npinnedRayDest micro-benchmark\n"
+       << "  iters / position   : " << kIters << '\n'
+       << "  total piece-calls  : " << pieceCallTotal << '\n'
+       << "  pinnedRayDest      : " << slowTotal << " s  ("
+       << slowNs << " ns/call)\n"
+       << "  pinnedRayDest_fast : " << fastTotal << " s  ("
+       << fastNs << " ns/call)\n"
+       << "  speedup            : " << speedup << "x\n" << std::flush;
+}
+
+static void
+helper()
 {
   // Argument : elsa help
 
@@ -132,6 +368,9 @@ helper()
   
   puts("** For Elsa's movegenerator self-speed test, type:\n");
   puts("** elsa speed\n");
+
+  puts("** For the isHashMoveLegal fuzz/equivalence test, type:\n");
+  puts("** elsa hashlegal\n");
 
   puts("** For Bulk-Counting, type:\n");
   puts("** elsa count [fen <fen>] [depth <depth>]\n");
@@ -347,8 +586,9 @@ task(const vector<string>& args)
     {"count",    [](const auto& arguments){ nodeCount(arguments); }},
     {"movegen",  [](const auto& arguments){ debugMoveGenerator(arguments); }},
     {"static",   [](const auto& arguments){ staticEval(arguments); }},
-    {"bestmove", [](const auto& arguments){ bestMoveSearch(arguments); }},
-    {"readyOk",  [](const auto&){ readyOk(); }}
+    {"bestmove",  [](const auto& arguments){ bestMoveSearch(arguments); }},
+    {"hashlegal", [](const auto&){ hashLegalTest(); }},
+    {"readyOk",   [](const auto&){ readyOk(); }}
   };
 
   // Search for any command in the args

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -1,7 +1,6 @@
-
+﻿
 #include <unordered_map>
 #include <functional>
-#include <set>
 #include "task.h"
 #include "search.h"
 #include "single_thread.h"
@@ -122,241 +121,6 @@ accuracyTest()
 }
 
 static void
-hashLegalTest()
-{
-  // Argument : elsa hashlegal
-  //
-  // Equivalence / fuzz test for isHashMoveLegal(). For each position in the
-  // suite below we build the reference set of legal moves (keyed on the 20 bits
-  // isHashMoveLegal actually consults — ip/fp/pIp/pFp/promo) and then check:
-  //   * every legal move is accepted              (no false negatives)
-  //   * no other move is accepted                 (no false positives)
-  //   * anything accepted survives a makeMove / integrityCheck / unmakeMove
-  //
-  // Run this before wiring isHashMoveLegal into the search.
-
-  // ---- gather FENs: the perft suites + a hand-picked set of delicate cases ----
-  std::vector<std::string> fens;
-
-  const auto addPerftSuite = [&] (const std::vector<std::string>& suite)
-  {
-    for (const auto& entry : suite)
-      fens.push_back(utils::strip(utils::split(entry, '|').front()));
-  };
-  addPerftSuite(test_data::accuracy::suite1);
-  addPerftSuite(test_data::speed::suite1);
-
-  const std::vector<std::string> tricky = {
-    "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",                      // castling: all four sides free
-    "r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 0 1",
-    "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-    "4k3/8/8/8/8/8/4r3/R3K2R w KQ - 0 1",                        // white in check on the e-file -> no castling
-    "r3k2r/8/8/8/8/5b2/8/R3K2R w KQkq - 0 1",                    // f3 bishop attacks g2/h1... and the queenside path
-    "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3",   // e.p. available (exd6)
-    "4k3/8/8/2Pp4/8/8/8/4K3 w - d6 0 1",                         // plain e.p.
-    "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",                 // famous e.p. discovered-check setup
-    "8/8/3p4/KPp4r/1R3p1k/8/4P1P1/8 w - c6 0 1",                 // ...with the e.p. square actually set
-    "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", // d7 pawn: push-promo + capture-promos
-    "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1",                   // a mess of promotions and capture-promotions
-    "rnbqkbnr/1ppppppp/p7/8/Q7/8/PPPPPPPP/RNB1KBNR b KQkq - 1 2",// black in check from Qa4 -> block / capture / Kd... no
-    "8/8/8/3k4/3Pp3/8/8/3KR3 b - d3 0 1",                        // pinned-ish pawn + e.p. interplay
-    "4k3/8/8/8/8/8/3p4/4K3 b - - 0 1",                           // black pawn one step from promotion, blocked path
-    "rnb1kbnr/pp1ppppp/8/q1p5/8/2P5/PP1PPPPP/RNBQKBNR w KQkq - 1 3",  // Qa5 pins... actually checks? no — diag to e1? no
-    "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", // dense, pins galore, a7 push-promos
-    "8/8/8/8/k2Pp2Q/8/8/4K3 b - d3 0 1",                         // black e4 pawn pinned by Qh4 along the 4th rank
-    "8/8/8/8/k1pP3R/8/8/4K3 b - d3 0 1",                         // e.p. capture by c4 would expose Rh4 -> illegal
-    START_FEN,
-  };
-  for (const auto& fen : tricky)
-    fens.push_back(fen);
-
-  // ---- simple deterministic PRNG for fuzzed candidates ----
-  uint64_t rngState = 0x9E3779B97F4A7C15ULL;
-  const auto nextRand = [&] () -> uint64_t
-  {
-    rngState ^= rngState << 13;
-    rngState ^= rngState >> 7;
-    rngState ^= rngState << 17;
-    return rngState;
-  };
-
-  size_t  posCount = 0;
-  size_t  refMoveTotal = 0;
-  size_t  candidatesChecked = 0;
-  size_t  falseNegatives = 0;
-  size_t  falsePositives = 0;
-  size_t  corruptions = 0;
-
-  // Canonical identity of a move under makeMove semantics: ip|fp|pIp|pFp, plus
-  // the promotion piece *only* when the destination is the promotion rank
-  // (otherwise makeMove — and isHashMoveLegal — never look at those two bits).
-  const auto canonKey = [] (Move m) -> Move
-  {
-    Move k = m & 0x3FFFF;
-    if (((m >> 12) & 7) == PAWN && ((1ULL << to_sq(m)) & Rank18))
-      k |= m & 0xC0000;
-    return k;
-  };
-
-  const auto reportFail = [] (const char* what, const std::string& fen, Move m)
-  {
-    cout << "  [FAIL] " << what
-         << "  fen = " << fen
-         << "  move = 0x" << std::hex << m << std::dec
-         << "  (" << char('a' + (m & 7)) << char('1' + ((m >> 3) & 7))
-         << char('a' + ((m >> 6) & 7)) << char('1' + ((m >> 9) & 7)) << ")\n";
-  };
-
-  for (const auto& fen : fens)
-  {
-    ChessBoard pos(fen);
-    ++posCount;
-
-    MoveList meta;
-    stagedGenerateMoves<GEN_METADATA>(pos, meta);
-
-    MoveList full = generateMoves(pos);
-    MoveArray legalMoves;
-    full.getMoves(pos, legalMoves);
-
-    std::set<Move> ref;
-    for (const Move m : legalMoves)
-      ref.insert(canonKey(m));
-    refMoveTotal += ref.size();
-
-    // ---- (a) no false negatives: every generated legal move must be accepted ----
-    for (const Move m : legalMoves)
-    {
-      ++candidatesChecked;
-      if (!isHashMoveLegal(m, pos, meta))
-      {
-        ++falseNegatives;
-        reportFail("false negative (legal move rejected)", fen, m);
-      }
-    }
-
-    const auto vet = [&] (Move c)
-    {
-      ++candidatesChecked;
-      if (!isHashMoveLegal(c, pos, meta))
-        return;
-      if (ref.find(canonKey(c)) == ref.end())
-      {
-        ++falsePositives;
-        reportFail("false positive (illegal move accepted)", fen, c);
-        return;
-      }
-      // accepted *and* genuinely legal — confirm makeMove keeps the board sane
-      pos.makeMove(c);
-      const bool ok = pos.integrityCheck() && (pos.hashValue == pos.generateHashkey());
-      pos.unmakeMove();
-      if (!ok)
-      {
-        ++corruptions;
-        reportFail("makeMove corrupted the board", fen, c);
-      }
-    };
-
-    // ---- (b) structured sweep: every (ip, fp) starting from one of our pieces,
-    //          correct pIp/pFp, and (for pawns) every promotion piece ----
-    Move colorBit = Move(pos.color) << 22;
-    for (int ipi = 0; ipi < SQUARE_NB; ++ipi)
-    {
-      Piece ipPiece = pos.pieceOnSquare(Square(ipi));
-      if (ipPiece == NO_PIECE || color_of(ipPiece) != pos.color)
-        continue;
-      PieceType ipt = type_of(ipPiece);
-
-      for (int fpi = 0; fpi < SQUARE_NB; ++fpi)
-      {
-        if (fpi == ipi) continue;
-        PieceType fpt = type_of(pos.pieceOnSquare(Square(fpi)));
-        Move base = colorBit | (Move(ipt) << 12) | (Move(fpt) << 15)
-                  | (Move(fpi) << 6) | Move(ipi);
-
-        if (ipt == PAWN)
-          for (Move promo = 0; promo < 4; ++promo)
-            vet(base | (promo << 18));
-        else
-          vet(base);
-
-        // a couple of deliberately-corrupt encodings (wrong pIp / pFp)
-        vet((base & ~(Move(7) << 12)) | (Move((ipt % 6) + 1) << 12));
-        vet((base & ~(Move(7) << 15)) | (Move((fpt + 1) & 7) << 15));
-      }
-    }
-
-    // ---- (c) near-misses of real legal moves: tweak one field by a little ----
-    for (const Move m : legalMoves)
-    {
-      vet(m ^ Move(1));                       // ip +/- 1
-      vet(m ^ (Move(1) << 6));                // fp +/- 1
-      vet(m ^ (Move(1) << 12));               // flip a pIp bit
-      vet(m ^ (Move(1) << 15));               // flip a pFp bit
-      vet(m ^ (Move(3) << 18));               // flip promo bits
-      vet(m ^ (Move(7) << 6));                // fp jumped by 7
-    }
-
-    // ---- (d) pure random 24-bit patterns ----
-    for (int i = 0; i < 4000; ++i)
-      vet(Move(nextRand() & 0xFFFFFF));
-  }
-
-  cout << "\nisHashMoveLegal fuzz test\n"
-       << "  positions          : " << posCount << '\n'
-       << "  legal moves (uniq) : " << refMoveTotal << '\n'
-       << "  candidates checked : " << candidatesChecked << '\n'
-       << "  false negatives    : " << falseNegatives << '\n'
-       << "  false positives    : " << falsePositives << '\n'
-       << "  board corruptions  : " << corruptions << '\n';
-
-  if (falseNegatives == 0 && falsePositives == 0 && corruptions == 0)
-    cout << "  RESULT             : PASS\n" << std::flush;
-  else
-    cout << "  RESULT             : FAIL\n" << std::flush;
-
-  // ---- micro-benchmark: pinnedRayDest (8-dir scan) vs pinnedRayDest_fast ----
-  // Same FEN list, every non-king own-side piece, kIters per position. The two
-  // functions are timed back-to-back inside benchmarkPinnedRayDest; we sum
-  // across positions to drown out single-call noise. Run a warm-up pass first.
-  constexpr int kIters = 20000;
-
-  double slowTotal = 0.0, fastTotal = 0.0;
-  size_t pieceCallTotal = 0;
-
-  for (const auto& fen : fens)
-  {
-    ChessBoard pos(fen);
-    benchmarkPinnedRayDest(pos, 200);                 // warm-up, discarded
-    const auto [slow, fast] = benchmarkPinnedRayDest(pos, kIters);
-    slowTotal += slow;
-    fastTotal += fast;
-
-    const Bitboard sideMask = (pos.color == WHITE)
-      ? (pos.piece<WHITE, PAWN>()  | pos.piece<WHITE, BISHOP>()
-       | pos.piece<WHITE, KNIGHT>()| pos.piece<WHITE, ROOK>()
-       | pos.piece<WHITE, QUEEN>())
-      : (pos.piece<BLACK, PAWN>()  | pos.piece<BLACK, BISHOP>()
-       | pos.piece<BLACK, KNIGHT>()| pos.piece<BLACK, ROOK>()
-       | pos.piece<BLACK, QUEEN>());
-    pieceCallTotal += size_t(__builtin_popcountll(sideMask)) * size_t(kIters);
-  }
-
-  const double slowNs = slowTotal * 1e9 / double(pieceCallTotal);
-  const double fastNs = fastTotal * 1e9 / double(pieceCallTotal);
-  const double speedup = (fastTotal > 0.0) ? (slowTotal / fastTotal) : 0.0;
-
-  cout << "\npinnedRayDest micro-benchmark\n"
-       << "  iters / position   : " << kIters << '\n'
-       << "  total piece-calls  : " << pieceCallTotal << '\n'
-       << "  pinnedRayDest      : " << slowTotal << " s  ("
-       << slowNs << " ns/call)\n"
-       << "  pinnedRayDest_fast : " << fastTotal << " s  ("
-       << fastNs << " ns/call)\n"
-       << "  speedup            : " << speedup << "x\n" << std::flush;
-}
-
-static void
 helper()
 {
   // Argument : elsa help
@@ -368,9 +132,6 @@ helper()
   
   puts("** For Elsa's movegenerator self-speed test, type:\n");
   puts("** elsa speed\n");
-
-  puts("** For the isHashMoveLegal fuzz/equivalence test, type:\n");
-  puts("** elsa hashlegal\n");
 
   puts("** For Bulk-Counting, type:\n");
   puts("** elsa count [fen <fen>] [depth <depth>]\n");
@@ -587,7 +348,6 @@ task(const vector<string>& args)
     {"movegen",  [](const auto& arguments){ debugMoveGenerator(arguments); }},
     {"static",   [](const auto& arguments){ staticEval(arguments); }},
     {"bestmove",  [](const auto& arguments){ bestMoveSearch(arguments); }},
-    {"hashlegal", [](const auto&){ hashLegalTest(); }},
     {"readyOk",   [](const auto&){ readyOk(); }}
   };
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -101,12 +101,14 @@ TranspositionTable::recordPosition
 
 int
 TranspositionTable::lookupPosition
-  (uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove) const noexcept
+  (uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove, bool& ttHit) const noexcept
 {
   const auto probe = [&] (const ZobristHashKey &key) -> int
   {
     if (key.hashValue != hashValue)
       return VALUE_UNKNOWN;
+
+    ttHit = true;
 
     // Hash match — surface the stored move for ordering, even when the
     // entry's depth is too shallow to produce a cutoff.
@@ -126,6 +128,7 @@ TranspositionTable::lookupPosition
   };
 
   outMove = NULL_MOVE;
+  ttHit = false;
 
   size_t index = hashValue % TT_SIZE;
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -83,13 +83,12 @@ TranspositionTable::hashKeyUpdate
 
 void
 TranspositionTable::recordPosition
-    (uint64_t hashValue, Depth depth, Score eval, Flag flag) noexcept
+    (uint64_t hashValue, Depth depth, Score eval, Flag flag, Move bestMove) noexcept
 {
   const auto addEntry = [&] (ZobristHashKey& key)
   {
     key.hashValue = hashValue;
-    key.eval = eval;
-    key.depthFlag = depth << 2 | int(flag);
+    key.pack(eval, depth, flag, bestMove);
   };
 
   size_t index = hashValue % TT_SIZE;
@@ -102,27 +101,38 @@ TranspositionTable::recordPosition
 
 int
 TranspositionTable::lookupPosition
-  (uint64_t hashValue, Depth depth, Score alpha, Score beta) const noexcept
+  (uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove) const noexcept
 {
-  const auto lookup = [&] (const ZobristHashKey &key)
+  const auto probe = [&] (const ZobristHashKey &key) -> int
   {
-    Flag flag = key.flag();
+    if (key.hashValue != hashValue)
+      return VALUE_UNKNOWN;
 
-    if (key.hashValue == hashValue and key.depth() > depth) {
-      if (flag == Flag::HASH_EXACT) return key.eval;
-      if (flag == Flag::HASH_ALPHA and key.eval <= alpha) return alpha;
-      if (flag == Flag::HASH_BETA  and key.eval >= beta ) return beta;
+    // Hash match — surface the stored move for ordering, even when the
+    // entry's depth is too shallow to produce a cutoff.
+    if (outMove == NULL_MOVE)
+      outMove = key.bestMove();
+
+    if (key.depth() > depth)
+    {
+      Flag flag = key.flag();
+      Score eval = key.eval();
+      if (flag == Flag::HASH_EXACT) return eval;
+      if (flag == Flag::HASH_ALPHA and eval <= alpha) return alpha;
+      if (flag == Flag::HASH_BETA  and eval >= beta ) return beta;
     }
 
-    return int(VALUE_UNKNOWN);
+    return VALUE_UNKNOWN;
   };
+
+  outMove = NULL_MOVE;
 
   size_t index = hashValue % TT_SIZE;
 
-  int res = lookup(ttPrimary[index]);
+  int res = probe(ttPrimary[index]);
   if (res != VALUE_UNKNOWN) return res;
 
-  return lookup(ttSecondary[index]);
+  return probe(ttSecondary[index]);
 }
 
 void

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -138,6 +138,20 @@ TranspositionTable::lookupPosition
   return probe(ttSecondary[index]);
 }
 
+Move
+TranspositionTable::probeMove(uint64_t hashValue) const noexcept
+{
+  size_t index = hashValue % TT_SIZE;
+
+  if (ttPrimary[index].hashValue == hashValue)
+    return ttPrimary[index].bestMove();
+
+  if (ttSecondary[index].hashValue == hashValue)
+    return ttSecondary[index].bestMove();
+
+  return NULL_MOVE;
+}
+
 void
 TranspositionTable::clear() noexcept
 {

--- a/src/tt.h
+++ b/src/tt.h
@@ -10,31 +10,62 @@
 
 using std::array;
 
+/**
+ * Packed TT entry — 16 bytes total.
+ *
+ * `data` layout (uint64_t):
+ *   bits  0..23 → bestMove   (24 bits, matches Move encoding width)
+ *   bits 24..31 → depth      (8 bits, unsigned)
+ *   bits 32..33 → flag       (2 bits)
+ *   bits 34..49 → eval       (16-bit signed, fits VALUE_INF = 16001)
+ *   bits 50..63 → reserved   (14 bits — aging, etc.)
+ */
 class ZobristHashKey
 {
   public:
   Bitboard hashValue;
-  Score         eval;
-  uint32_t depthFlag;
+  uint64_t data;
 
-  ZobristHashKey() : hashValue(0) {}
+  ZobristHashKey() : hashValue(0), data(0) {}
+
+  inline Move
+  bestMove() const noexcept
+  { return Move(data & 0xFFFFFFULL); }
 
   inline Depth
   depth() const noexcept
-  { return depthFlag >> 2; }
+  { return Depth((data >> 24) & 0xFFULL); }
 
   inline Flag
   flag() const noexcept
-  { return Flag(depthFlag & 3); }
+  { return Flag((data >> 32) & 0x3ULL); }
+
+  inline Score
+  eval() const noexcept
+  {
+    // sign-extend the 16-bit eval field
+    int16_t v = int16_t((data >> 34) & 0xFFFFULL);
+    return Score(v);
+  }
+
+  inline void
+  pack(Score eval, Depth depth, Flag flag, Move bestMove) noexcept
+  {
+    data = (uint64_t(bestMove) & 0xFFFFFFULL)
+         | ((uint64_t(depth) & 0xFFULL) << 24)
+         | ((uint64_t(flag)  & 0x3ULL) << 32)
+         | ((uint64_t(uint16_t(int16_t(eval))) & 0xFFFFULL) << 34);
+  }
 
   void
   show() const noexcept
   {
-    std::cout 
+    std::cout
       << "Key = " << hashValue << '\n'
       << "Depth = " << depth() << '\n'
-      << "Eval = " << eval << '\n'
-      << "Flag = " << int(flag()) << std::endl;
+      << "Eval = " << eval() << '\n'
+      << "Flag = " << int(flag()) << '\n'
+      << "BestMove = " << bestMove() << std::endl;
   }
 };
 
@@ -42,7 +73,7 @@ class TranspositionTable
 {
   /**
    * 0 ->  66 MB tableSize
-   * 1 -> 686 MB tableSize 
+   * 1 -> 686 MB tableSize
   */
   array<uint64_t, 2> ttSizes = { 2189477ULL, 22508861ULL };
 
@@ -83,10 +114,10 @@ class TranspositionTable
   hashKeyUpdate(int piece, int pos) const noexcept;
 
   void
-  recordPosition(uint64_t hashValue, Depth depth, Score eval, Flag flag) noexcept;
-  
+  recordPosition(uint64_t hashValue, Depth depth, Score eval, Flag flag, Move bestMove) noexcept;
+
   int
-  lookupPosition(uint64_t hashValue, Depth depth, Score alpha, Score beta) const noexcept;
+  lookupPosition(uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove) const noexcept;
 };
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -118,6 +118,11 @@ class TranspositionTable
 
   int
   lookupPosition(uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove, bool& ttHit) const noexcept;
+
+  // Fetch just the stored best move for a position — no flag/eval/depth logic,
+  // no terminal dependency. Used to try the hash move before full move generation.
+  Move
+  probeMove(uint64_t hashValue) const noexcept;
 };
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -117,7 +117,7 @@ class TranspositionTable
   recordPosition(uint64_t hashValue, Depth depth, Score eval, Flag flag, Move bestMove) noexcept;
 
   int
-  lookupPosition(uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove) const noexcept;
+  lookupPosition(uint64_t hashValue, Depth depth, Score alpha, Score beta, Move& outMove, bool& ttHit) const noexcept;
 };
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -160,7 +160,8 @@ enum class MType: uint8_t
   CHECK     = 1 << 2,
   PROMOTION = 1 << 3,
   PV = 1 << 4,
-  KILLER = 1 << 5
+  KILLER = 1 << 5,
+  HASH_MOVE = 1 << 6
 };
 
 /**

--- a/src/types.h
+++ b/src/types.h
@@ -161,7 +161,6 @@ enum class MType: uint8_t
   PROMOTION = 1 << 3,
   PV = 1 << 4,
   KILLER = 1 << 5,
-  HASH_MOVE = 1 << 6
 };
 
 /**

--- a/src/varray.h
+++ b/src/varray.h
@@ -31,6 +31,10 @@ class Varray {
   clear() noexcept
   { Nc = 0; }
 
+  void
+  popBack() noexcept
+  { if (Nc > 0) --Nc; }
+
   T&
   operator[](size_t index) noexcept
   { return _array[index]; }


### PR DESCRIPTION
Adds TT best-move ordering on top of staged move generation. `alphaBeta` now probes the TT before any movegen, runs only `GEN_METADATA` + `GEN_MOVES` for the terminal/draw checks, and takes a hash-move fast-path (gated by standalone `isLegalMoveForPosition_V2`) that skips `GEN_CHECKS` + the full ordering pipeline on a beta cutoff. `MoveList::removeMove` keeps the staged loop from re-emitting the hash move, and LMR reads `removedMoves()` to keep its index aligned.

## Arena results

1000 games at 1s + 0.1s vs `master`: **533W / 295D / 172L → 68.05% → +131 Elo** (LOS ≈ 100%).