### PR TITLE
Demote SEE<0 captures past killers/quiets (+13 Elo)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -44,6 +44,18 @@ orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, 
   if (mTypes != MType::QUIET)
     std::sort(movesArray.begin() + prevS, movesArray.begin() + start, seeComparator);
 
+  // Bad-capture demotion (improvements.md #1). On the dedicated CAPTURES
+  // stage the band is now SEE-sorted descending, so SEE<0 captures sit at
+  // the back. Pull `start` left past them — they stay in the array and get
+  // picked up by the QUIET-tail stage (which plays everything remaining),
+  // i.e. *after* killers/PV/checks. Search effort no longer gets spent on
+  // e.g. QxP-defended-by-pawn before any quiet move is tried.
+  if (mTypes == MType::CAPTURES)
+  {
+    while (start > prevS and seeScore(pos, movesArray[start - 1]) < 0)
+      --start;
+  }
+
   if (hasFlag(mTypes, MType::KILLER))
   {
     for (size_t i = start; i < movesArray.size(); i++) {


### PR DESCRIPTION
Splits captures by SEE sign in `orderMoves`: SEE≥0 captures stay at the front of the band, SEE<0 captures fall through to the QUIET-tail stage and get tried *after* PV / checks / killers / quiets. No new `MType`, no `playAllMoves<>` restructure — the captures stage just returns a smaller `start`, leaving bad captures in the array where the catch-all QUIET stage picks them up.

Arena results
1000 games at 1s + 0.1s vs master: 349W / 339D / 312L → 51.85% → +13 Elo (LOS ≈ 92%).