### PR TITLE
Texel weight tuner + first arena-validated weight bump (+32 Elo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.in
 *.out
 *.exe
+*.epd
 
 output
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ For benchmarking, debugging, and scripted use, Elsa also exposes a CLI. Argument
 - `elsa count [fen <fen>] [depth <d>]` — perft node count with timing
 - `elsa movegen [fen <fen>] [depth <d>] [output <file>]` — dump per-root-move perft breakdown
 - `elsa static [fen <fen>]` — print ordered moves and static evaluation
+- `elsa tune [data <path.epd>] [iters <n>]` — Texel-tune the evaluation blend weights against a labeled EPD set
+- `elsa tune --all [dir <folder>] [iters <n>]` — run the tuner across every `.epd` file in a folder
 - `elsa readyOk` — quick smoke test (perft 3 from startpos = 8902)
 
 ### Example

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -7,6 +7,8 @@
 using std::abs;
 using std::min;
 
+EvalWeights evalWeights;
+
 static int
 distance(Square s, Square t)
 {
@@ -420,11 +422,11 @@ midGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
   }
 
   float eval =
-      ed.materialWeight     * float(materialScore)
-    + ed.pieceTableWeight   * float(pieceTableScore)
-    + ed.mobilityWeight     * float(mobilityScore)
-    + ed.pawnStructureWeight * float(pawnStructure)
-    + ed.threatsWeight      * float(threatsScore);
+      evalWeights.materialWeightMg      * float(materialScore)
+    + evalWeights.pieceTableWeightMg    * float(pieceTableScore)
+    + evalWeights.mobilityWeightMg      * float(mobilityScore)
+    + evalWeights.pawnStructureWeightMg * float(pawnStructure)
+    + evalWeights.threatsWeightMg       * float(threatsScore);
 
   return Score(eval);
 }
@@ -565,10 +567,10 @@ endGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
   }
 
   float eval =
-      ed.materialWeight     * float(materialScore)
-    + ed.pieceTableWeight   * float(pieceTableScore)
-    + 0.7f                  * float(pawnStructure)
-    + float(distanceScore);
+      evalWeights.materialWeightEg      * float(materialScore)
+    + evalWeights.pieceTableWeightEg    * float(pieceTableScore)
+    + evalWeights.pawnStructureWeightEg * float(pawnStructure)
+    + evalWeights.distanceWeightEg      * float(distanceScore);
 
   return Score(eval);
 }
@@ -646,3 +648,79 @@ template Score threats<true >(const ChessBoard& pos);
 
 template Score evaluate<false>(const ChessBoard& pos);
 template Score evaluate<true >(const ChessBoard& pos);
+
+
+EvalComponents
+extractEvalComponents(const ChessBoard& pos)
+{
+  EvalComponents ec;
+
+  EvalData ed = EvalData(pos);
+  float phase = ed.phase;
+  int pieceCount = pos.count<ALL>();
+
+  // Special endgames bypass the weighted eval entirely (see evaluate()): their score
+  // does not depend on the 9 weights, so they are not tunable.
+  if (pieceCount < 3)
+  {
+    if (pieceCount == 2
+    and pos.count<PAWN  >() == 1
+    and pos.count<BISHOP>() == 1
+    and pos.count<WHITE, ALL>() == 1)
+      return ec;  // bishopPawnEndgame, tunable = false
+  }
+
+  if ((pos.count<PAWN>() == 0) and (ed.pieces[WHITE] == 0 or ed.pieces[BLACK] == 0))
+    return ec;  // loneKingEndGame, tunable = false
+
+  // Shared pawn-structure subtotal (white - black), computed once as in evaluate().
+  Score pawnStructure =
+      pawnStructureScore<WHITE>(pos, ed) - pawnStructureScore<BLACK>(pos, ed);
+  ed.pawnStructureScore = pawnStructure;
+
+  ec.tunable = true;
+  ec.phase   = phase;
+
+  // Midgame components — zeroed exactly when midGameScore early-returns (phase < 0.2).
+  if (!(phase < 0.2))
+  {
+    ec.matMg    = float(materialDiffereceMidGame(pos));
+    ec.ptMg     = float(pieceTableStrengthMidGame(pos));
+    ec.mobility = float(mobilityStrength(pos));
+    ec.pawnMg   = float(pawnStructure);
+    ec.threats  = float(threats<false>(pos));
+  }
+
+  // Endgame components — zeroed exactly when endGameScore early-returns (1 - phase < 0.2).
+  if (!((1 - phase) < 0.2))
+  {
+    ec.matEg    = float(materialDiffereceEndGame(pos));
+    ec.ptEg     = float(pieceTableStrengthEndGame(pos));
+    ec.pawnEg   = float(pawnStructure);
+    ec.distance = float(distanceBetweenKingsScore(pos));
+  }
+
+  return ec;
+}
+
+Score
+evalFromComponents(const EvalComponents& ec, const EvalWeights& w)
+{
+  float mg =
+      w.materialWeightMg      * ec.matMg
+    + w.pieceTableWeightMg    * ec.ptMg
+    + w.mobilityWeightMg      * ec.mobility
+    + w.pawnStructureWeightMg * ec.pawnMg
+    + w.threatsWeightMg       * ec.threats;
+
+  float eg =
+      w.materialWeightEg      * ec.matEg
+    + w.pieceTableWeightEg    * ec.ptEg
+    + w.pawnStructureWeightEg * ec.pawnEg
+    + w.distanceWeightEg      * ec.distance;
+
+  // Match evaluate(): mg/eg are truncated to Score (int32) before the phase blend.
+  Score mgScore = Score(mg);
+  Score egScore = Score(eg);
+  return Score( ec.phase * float(mgScore) + (1 - ec.phase) * float(egScore) );
+}

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -350,12 +350,10 @@ canSafelyPromote(const ChessBoard& pos, Square pawnSq)
 
 template <Color cMy>
 static Score
-pawnStructureScore(const ChessBoard& pos, const EvalData& ed)
+pawnStructureScoreMidgame(const ChessBoard& pos)
 {
-  constexpr Color cEmy = ~cMy;
-  Bitboard    pawns = pos.piece<cMy , PAWN>();
-  Bitboard emyPawns = pos.piece<cEmy, PAWN>();
-  Bitboard   column = FileA;
+  Bitboard  pawns = pos.piece<cMy , PAWN>();
+  Bitboard column = FileA;
   Score score = 0;
 
   // Punish Double Pawns on same column
@@ -366,41 +364,12 @@ pawnStructureScore(const ChessBoard& pos, const EvalData& ed)
     column <<= 1;
   }
 
-  while (pawns != 0)
-  {
-    Square pawnSq = nextSquare(pawns);
-    if ((plt::passedPawnMasks[cMy][pawnSq] & emyPawns) != 0)
-      continue;
-
-    if (isPassedPawn<cMy>(pos, pawnSq))
-    {
-      // Reward for passed pawn
-      Score rankProgress = (7 * (cMy ^ 1)) + (pawnSq >> 3) * (2 * cMy - 1);
-      score += 3 * rankProgress * rankProgress;
-
-      if (canSafelyPromote<cMy>(pos, pawnSq))
-      {
-        Score reward = ed.pieces[cEmy] == 0 ? QueenValueEg : PawnValueEg >> 2;
-        score += reward + 3 * rankProgress * rankProgress;
-      }
-    }
-
-    Square  kpos = squareNo(pos.piece< cMy, KING>());
-    Square ekpos = squareNo(pos.piece<cEmy, KING>());
-
-    // TODO: More points for being close to pawn which is closer to promotion
-    // Add score for king close to passed pawn and
-    // Reduce score if enemy king is close to pawn
-    int dist = (14 - distance(pawnSq, kpos)) - (14 - distance(pawnSq, ekpos));
-    score += 6 * dist;
-  }
-
   return score;
 }
 
 template<bool debug>
 static Score
-midGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
+midGameScore(const ChessBoard& pos, float phase)
 {
   if (phase < 0.2)
     return 0;
@@ -408,7 +377,8 @@ midGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
   Score materialScore   = materialDiffereceMidGame(pos);
   Score pieceTableScore = pieceTableStrengthMidGame(pos);
   Score mobilityScore   = mobilityStrength(pos);
-  Score pawnStructure   = ed.pawnStructureScore;
+  Score pawnStructure   = pawnStructureScoreMidgame<WHITE>(pos)
+                        - pawnStructureScoreMidgame<BLACK>(pos);
   Score threatsScore    = threats<debug>(pos);
 
   if (debug)
@@ -417,6 +387,7 @@ midGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
       << "\nmaterialScore   = " << materialScore
       << "\npieceTableScore = " << pieceTableScore
       << "\nmobilityScore   = " << mobilityScore
+      << "\npawnStructure   = " << pawnStructure
       << "\nthreatsScore    = " << threatsScore
       << "\n-------------------------------------------------" << endl;
   }
@@ -538,6 +509,53 @@ pieceTableStrengthEndGame(const ChessBoard& pos)
   return king;
 }
 
+template <Color cMy>
+static Score
+pawnStructureScoreEndgame(const ChessBoard& pos, const EvalData& ed)
+{
+  constexpr Color cEmy = ~cMy;
+  Bitboard    pawns = pos.piece<cMy , PAWN>();
+  Bitboard   column = FileA;
+  Score score = 0;
+
+  // Punish Double Pawns on same column
+  for (int i = 0; i < 8; i++)
+  {
+    int p = popCount(column & pawns);
+    score -= 52 * p * (p - 1);
+    column <<= 1;
+  }
+
+  while (pawns != 0)
+  {
+    Square pawnSq = nextSquare(pawns);
+
+    if (isPassedPawn<cMy>(pos, pawnSq))
+    {
+      // Reward for passed pawn
+      Score rankProgress = (7 * (cMy ^ 1)) + (pawnSq >> 3) * (2 * cMy - 1);
+      score += 3 * rankProgress * rankProgress;
+
+      if (canSafelyPromote<cMy>(pos, pawnSq))
+      {
+        Score reward = ed.pieces[cEmy] == 0 ? QueenValueEg : PawnValueEg >> 2;
+        score += reward + 3 * rankProgress * rankProgress;
+      }
+    }
+
+    Square  kpos = squareNo(pos.piece< cMy, KING>());
+    Square ekpos = squareNo(pos.piece<cEmy, KING>());
+
+    // TODO: More points for being close to pawn which is closer to promotion
+    // Add score for king close to passed pawn and
+    // Reduce score if enemy king is close to pawn
+    int dist = (14 - distance(pawnSq, kpos)) - (14 - distance(pawnSq, ekpos));
+    score += 6 * dist;
+  }
+
+  return score;
+}
+
 template<bool debug>
 static Score
 endGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
@@ -552,9 +570,9 @@ endGameScore(const ChessBoard& pos, const EvalData& ed, float phase)
 
   Score materialScore   = materialDiffereceEndGame(pos);
   Score pieceTableScore = pieceTableStrengthEndGame(pos);
-  Score pawnStructure   = ed.pawnStructureScore;
+  Score pawnStructure   = pawnStructureScoreEndgame<WHITE>(pos, ed)
+                        - pawnStructureScoreEndgame<BLACK>(pos, ed);
   Score distanceScore   = distanceBetweenKingsScore(pos);
-  // Score threatsScore    = ed.threatScore;
 
   if (debug)
   {
@@ -615,18 +633,7 @@ evaluate(const ChessBoard& pos)
     return score * side2move;
   }
 
-  Score pawnStructrueWhite = pawnStructureScore<WHITE>(pos, ed);
-  Score pawnStructrueBlack = pawnStructureScore<BLACK>(pos, ed);
-  ed.pawnStructureScore = pawnStructrueWhite - pawnStructrueBlack;
-
-  if (debug)
-  {
-    cout << "Score_pawn_structure_white = " << pawnStructrueWhite << endl;
-    cout << "Score_pawn_structure_black = " << pawnStructrueBlack << endl;
-    cout << "Score_pawn_structure_total = " << ed.pawnStructureScore << endl << endl;
-  }
-
-  Score mgScore = midGameScore<debug>(pos, ed,     phase);
+  Score mgScore = midGameScore<debug>(pos, phase);
   Score egScore = endGameScore<debug>(pos, ed, 1 - phase);
 
   Score score = Score( phase * float(mgScore) + (1 - phase) * float(egScore) );
@@ -673,11 +680,6 @@ extractEvalComponents(const ChessBoard& pos)
   if ((pos.count<PAWN>() == 0) and (ed.pieces[WHITE] == 0 or ed.pieces[BLACK] == 0))
     return ec;  // loneKingEndGame, tunable = false
 
-  // Shared pawn-structure subtotal (white - black), computed once as in evaluate().
-  Score pawnStructure =
-      pawnStructureScore<WHITE>(pos, ed) - pawnStructureScore<BLACK>(pos, ed);
-  ed.pawnStructureScore = pawnStructure;
-
   ec.tunable = true;
   ec.phase   = phase;
 
@@ -687,7 +689,8 @@ extractEvalComponents(const ChessBoard& pos)
     ec.matMg    = float(materialDiffereceMidGame(pos));
     ec.ptMg     = float(pieceTableStrengthMidGame(pos));
     ec.mobility = float(mobilityStrength(pos));
-    ec.pawnMg   = float(pawnStructure);
+    ec.pawnMg   = float(pawnStructureScoreMidgame<WHITE>(pos)
+                - pawnStructureScoreMidgame<BLACK>(pos));
     ec.threats  = float(threats<false>(pos));
   }
 
@@ -696,7 +699,8 @@ extractEvalComponents(const ChessBoard& pos)
   {
     ec.matEg    = float(materialDiffereceEndGame(pos));
     ec.ptEg     = float(pieceTableStrengthEndGame(pos));
-    ec.pawnEg   = float(pawnStructure);
+    ec.pawnEg   = float(pawnStructureScoreEndgame<WHITE>(pos, ed)
+                - pawnStructureScoreEndgame<BLACK>(pos, ed));
     ec.distance = float(distanceBetweenKingsScore(pos));
   }
 

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -28,9 +28,6 @@ class EvalData
 	int boardWeight;
 	float phase;
 
-	Score pawnStructureScore;
-	Score threatScore;
-
 	EvalData(const ChessBoard& pos)
 	{
 		materialCount<WHITE>(pos);
@@ -60,10 +57,10 @@ struct EvalWeights
 	float materialWeightEg      = 1.0f;
 	float pieceTableWeightMg    = 1.8f;
 	float pieceTableWeightEg    = 1.8f;
-	float pawnStructureWeightMg = 0.4f;
+	float pawnStructureWeightMg = 0.15f;
 	float pawnStructureWeightEg = 0.7f;
-	float mobilityWeightMg      = 1.2f;  // midgame-only
-	float threatsWeightMg       = 0.5f;  // midgame-only
+	float mobilityWeightMg      = 2.2f;  // midgame-only
+	float threatsWeightMg       = 0.7f;  // midgame-only
 	float distanceWeightEg      = 1.0f;  // endgame-only king-distance term
 };
 
@@ -92,8 +89,9 @@ struct EvalComponents
 	float phase   = 0.0f;
 	// midgame components (zeroed when phase < 0.2)
 	float matMg = 0.0f, ptMg = 0.0f, pawnMg = 0.0f, mobility = 0.0f, threats = 0.0f;
-	// endgame components (zeroed when 1 - phase < 0.2); pawnEg is the same raw
-	// pawn-structure subtotal as pawnMg, kept separate for independent phase zeroing
+	// endgame components (zeroed when 1 - phase < 0.2); pawnEg is the endgame pawn-structure
+	// subtotal (passers / king-escort / safe-promote + doubled), distinct from the midgame
+	// pawnMg (doubled-pawn penalty only)
 	float matEg = 0.0f, ptEg = 0.0f, pawnEg = 0.0f, distance = 0.0f;
 };
 

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -31,12 +31,6 @@ class EvalData
 	Score pawnStructureScore;
 	Score threatScore;
 
-	constexpr static float materialWeight = 1.0f;
-	constexpr static float pieceTableWeight = 1.8f;
-	constexpr static float threatsWeight = 0.5f;
-	constexpr static float mobilityWeight = 1.2f;
-	constexpr static float pawnStructureWeight = 0.4f;
-
 	EvalData(const ChessBoard& pos)
 	{
 		materialCount<WHITE>(pos);
@@ -55,6 +49,26 @@ class EvalData
 	{ return pos.count<BLACK, PAWN>() + pieces[BLACK] == 0; }
 };
 
+// Runtime-tunable evaluation blend weights (mg/eg split). Each weight scales a
+// per-component subtotal before the midgame/endgame scores are blended. A single
+// global instance is mutated in place by the Texel tuner between iterations (the
+// engine is single-threaded). Mobility and threats are midgame-only and king-distance
+// is endgame-only, matching how midGameScore/endGameScore use them.
+struct EvalWeights
+{
+	float materialWeightMg      = 1.0f;
+	float materialWeightEg      = 1.0f;
+	float pieceTableWeightMg    = 1.8f;
+	float pieceTableWeightEg    = 1.8f;
+	float pawnStructureWeightMg = 0.4f;
+	float pawnStructureWeightEg = 0.7f;
+	float mobilityWeightMg      = 1.2f;  // midgame-only
+	float threatsWeightMg       = 0.5f;  // midgame-only
+	float distanceWeightEg      = 1.0f;  // endgame-only king-distance term
+};
+
+extern EvalWeights evalWeights;
+
 template <bool debug=false>
 Score
 threats(const ChessBoard& pos);
@@ -62,6 +76,36 @@ threats(const ChessBoard& pos);
 template <bool debug=false>
 Score
 evaluate(const ChessBoard& pos);
+
+
+// White-relative per-component eval subtotals for one position, cached by the Texel
+// tuner so each iteration is pure arithmetic (no board/movegen). The blend is linear
+// in the weights given these subtotals + phase.
+//
+// Subtotals are already zeroed for the phase that early-returns in evaluate()
+// (mg when phase < 0.2, eg when 1 - phase < 0.2), so evalFromComponents() reproduces
+// evaluate<false>() (white-relative) exactly. `tunable` is false for special endgames
+// (loneKing / bishopPawn) which bypass the weighted eval — those must be skipped.
+struct EvalComponents
+{
+	bool  tunable = false;
+	float phase   = 0.0f;
+	// midgame components (zeroed when phase < 0.2)
+	float matMg = 0.0f, ptMg = 0.0f, pawnMg = 0.0f, mobility = 0.0f, threats = 0.0f;
+	// endgame components (zeroed when 1 - phase < 0.2); pawnEg is the same raw
+	// pawn-structure subtotal as pawnMg, kept separate for independent phase zeroing
+	float matEg = 0.0f, ptEg = 0.0f, pawnEg = 0.0f, distance = 0.0f;
+};
+
+// Extract the white-relative component subtotals for a position.
+EvalComponents
+extractEvalComponents(const ChessBoard& pos);
+
+// Reconstruct the white-relative static eval from cached components + weights.
+// Mirrors evaluate()'s arithmetic exactly, including the int truncation of the mg/eg
+// subscores before the phase blend.
+Score
+evalFromComponents(const EvalComponents& ec, const EvalWeights& w);
 
 
 #endif

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -5,6 +5,7 @@
 #include "search.h"
 #include "single_thread.h"
 #include "test_positions.h"
+#include "tuner.h"
 
 void
 init(const vector<string>& args)
@@ -144,6 +145,9 @@ helper()
   
   puts("** For static evaluation of a position, type:\n");
   puts("** elsa static [fen <fen>]\n");
+
+  puts("** For tuning evaluation weights (Texel), type:\n");
+  puts("** elsa tune [data <path.epd>] [iters <n>]\n");
 
   puts("** Note: Commands and flags can be in any order\n");
   puts("         (e.g. 'elsa debug depth 3 fen <fen>' or 'elsa fen <fen> go')\n");
@@ -348,7 +352,8 @@ task(const vector<string>& args)
     {"movegen",  [](const auto& arguments){ debugMoveGenerator(arguments); }},
     {"static",   [](const auto& arguments){ staticEval(arguments); }},
     {"bestmove",  [](const auto& arguments){ bestMoveSearch(arguments); }},
-    {"readyOk",   [](const auto&){ readyOk(); }}
+    {"readyOk",   [](const auto&){ readyOk(); }},
+    {"tune",      [](const auto& arguments){ tuneEval(arguments); }}
   };
 
   // Search for any command in the args

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -148,6 +148,7 @@ helper()
 
   puts("** For tuning evaluation weights (Texel), type:\n");
   puts("** elsa tune [data <path.epd>] [iters <n>]\n");
+  puts("** elsa tune --all [dir <folder>] [iters <n>]   (tune every .epd in folder)\n");
 
   puts("** Note: Commands and flags can be in any order\n");
   puts("         (e.g. 'elsa debug depth 3 fen <fen>' or 'elsa fen <fen> go')\n");

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -1,0 +1,328 @@
+
+#include <fstream>
+#include <cmath>
+#include <iomanip>
+#include <array>
+
+#include "tuner.h"
+#include "bitboard.h"
+#include "evaluation.h"
+#include "base_utils.h"
+#include "perf.h"
+
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
+
+namespace {
+
+// One cached training position: the white-relative component subtotals (weight-independent)
+// plus the game result label in {1.0, 0.5, 0.0}. Re-evaluating it for a candidate weight
+// set is pure arithmetic via evalFromComponents — no board, movegen or attack lookups.
+struct TuneEntry
+{
+  EvalComponents ec;
+  double result;
+};
+
+// White-relative static eval. evaluate() returns it side-to-move-relative as
+// score * side2move; multiplying by side2move again (it is +-1) recovers the white POV.
+Score
+whiteRelativeEval(const ChessBoard& pos)
+{
+  const Score side2move = Score(2 * int(pos.color) - 1);
+  return evaluate<false>(pos) * side2move;
+}
+
+// sigmoid(K * eval / 400) using the base-10 logistic, matching the Texel error model.
+double
+winProbability(Score eval, double K)
+{
+  return 1.0 / (1.0 + std::pow(10.0, -K * double(eval) / 400.0));
+}
+
+// Mean squared error of the cached dataset under scaling constant K and weights w.
+double
+meanSquaredError(const vector<TuneEntry>& data, double K, const EvalWeights& w)
+{
+  double total = 0.0;
+  for (const auto& e : data)
+  {
+    const Score eval = evalFromComponents(e.ec, w);
+    const double diff = e.result - winProbability(eval, K);
+    total += diff * diff;
+  }
+  return total / double(data.size());
+}
+
+// Correctness gate: the cached-component reconstruction (evalFromComponents) must
+// reproduce the real white-relative eval bit-for-bit on tunable positions, and special
+// endgames must be flagged non-tunable (skipped). Returns false on any mismatch so the
+// caller can refuse to tune against a broken cache.
+bool
+runSelfCheck()
+{
+  // startpos, a few middlegames, low-phase / pawn endgames, and special endgames
+  // (lone-king variants + bishop-pawn) that bypass the weighted eval.
+  static const std::array<const char*, 12> fens = {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4",
+    "r2q1rk1/pp2bppp/2n1bn2/2pp4/3P4/2N1PN2/PP2BPPP/R1BQ1RK1 w - - 0 9",
+    "r3k2r/1bp2ppp/p1np1n2/1p2p3/4P3/1BPP1N2/PP3PPP/RNBQ1RK1 b kq - 0 9",
+    "8/2p2pkp/3p2p1/8/2P1P3/3P2P1/5PKP/8 w - - 0 1",
+    "8/5k2/8/8/8/8/3K1P2/8 w - - 0 1",       // K+P vs K  (low phase, mg-zeroed)
+    "8/8/8/4k3/8/8/4K3/8 w - - 0 1",          // K vs K    (lone king, skip)
+    "8/8/8/4k3/8/8/4KQ2/8 w - - 0 1",         // KQ vs K   (lone king, skip)
+    "8/8/8/4k3/8/8/3KBN2/8 w - - 0 1",        // KBN vs K  (lone king, skip)
+    "8/4kp2/8/8/8/8/4KB2/8 w - - 0 1",        // KB vs KP  (bishop-pawn, skip)
+    "6k1/5ppp/8/8/8/8/5PPP/6K1 w - - 0 1",
+    "8/8/4k3/8/8/3K4/4P3/8 w - - 0 1"         // K+P vs K  (low phase, mg-zeroed)
+  };
+
+  int checked = 0, skipped = 0, mismatches = 0;
+  Score maxDiff = 0;
+
+  for (const char* fen : fens)
+  {
+    ChessBoard pos(fen);
+    const EvalComponents ec = extractEvalComponents(pos);
+
+    if (!ec.tunable) { ++skipped; continue; }
+
+    const Score got = evalFromComponents(ec, evalWeights);
+    const Score want = whiteRelativeEval(pos);
+    const Score diff = Score(std::abs(int(got - want)));
+
+    if (diff != 0)
+    {
+      ++mismatches;
+      maxDiff = std::max(maxDiff, diff);
+      cout << "  MISMATCH  got=" << got << " want=" << want
+           << "  fen=" << fen << '\n';
+    }
+    ++checked;
+  }
+
+  cout << "Self-check: " << checked << " reconstructed, " << skipped
+       << " skipped (special endgames), " << mismatches
+       << " mismatches, maxDiff=" << maxDiff << '\n';
+
+  return mismatches == 0;
+}
+
+// "1-0" -> 1.0, "0-1" -> 0.0, "1/2-1/2" -> 0.5; also tolerates numeric "1.0"/"0.5"/"0.0".
+// Returns false if the token is unrecognised.
+bool
+parseResult(const string& token, double& out)
+{
+  if (token.find("1/2") != string::npos || token.find("0.5") != string::npos)
+    { out = 0.5; return true; }
+  if (token.find("1-0") != string::npos || token.find("1.0") != string::npos)
+    { out = 1.0; return true; }
+  if (token.find("0-1") != string::npos || token.find("0.0") != string::npos)
+    { out = 0.0; return true; }
+  return false;
+}
+
+// Pads an EPD position (4 fields: board, side, castling, ep) to a full 6-field FEN so
+// the ChessBoard parser is happy; leaves already-complete FENs untouched.
+string
+toFullFen(const string& position)
+{
+  vector<string> fields;
+  for (const auto& f : utils::split(position, ' '))
+    if (!f.empty()) fields.push_back(f);
+
+  if (fields.size() < 4) return position;  // malformed; let the caller skip it
+
+  string fen = fields[0] + ' ' + fields[1] + ' ' + fields[2] + ' ' + fields[3];
+  fen += (fields.size() >= 6) ? (' ' + fields[4] + ' ' + fields[5]) : string(" 0 1");
+  return fen;
+}
+
+// Parses a Zurichess-style labeled EPD line: `<position> ... c9 "RESULT";`.
+// Builds the component cache for tunable positions; counts skips/parse failures.
+vector<TuneEntry>
+loadDataset(const string& path)
+{
+  vector<TuneEntry> data;
+  std::ifstream in(path);
+  if (!in)
+  {
+    cout << "Could not open dataset: " << path << '\n';
+    return data;
+  }
+
+  size_t lines = 0, parseFail = 0, special = 0;
+  string line;
+
+  while (std::getline(in, line))
+  {
+    if (line.empty()) continue;
+    ++lines;
+
+    const size_t tag = line.find("c9");
+    if (tag == string::npos) { ++parseFail; continue; }
+
+    const size_t q1 = line.find('"', tag);
+    const size_t q2 = (q1 == string::npos) ? string::npos : line.find('"', q1 + 1);
+    if (q2 == string::npos) { ++parseFail; continue; }
+
+    double result;
+    if (!parseResult(line.substr(q1 + 1, q2 - q1 - 1), result)) { ++parseFail; continue; }
+
+    const string fen = toFullFen(line.substr(0, tag));
+    ChessBoard pos(fen);
+
+    const EvalComponents ec = extractEvalComponents(pos);
+    if (!ec.tunable) { ++special; continue; }
+
+    data.push_back({ec, result});
+  }
+
+  cout << "Loaded " << lines << " lines: " << data.size() << " tunable, "
+       << special << " special-endgame skips, " << parseFail << " parse failures.\n";
+  return data;
+}
+
+// Ternary search for the K that minimises MSE at the current weights (MSE(K) is unimodal).
+double
+fitK(const vector<TuneEntry>& data, const EvalWeights& w)
+{
+  double lo = 0.0, hi = 3.0;
+  for (int i = 0; i < 40; ++i)
+  {
+    const double m1 = lo + (hi - lo) / 3.0;
+    const double m2 = hi - (hi - lo) / 3.0;
+    if (meanSquaredError(data, m1, w) < meanSquaredError(data, m2, w))
+      hi = m2;
+    else
+      lo = m1;
+  }
+  return (lo + hi) / 2.0;
+}
+
+// The 9 tunable weights, exposed as named handles into a weight set for coordinate descent.
+struct WeightRef { const char* name; float EvalWeights::* member; };
+
+static const std::array<WeightRef, 9> WEIGHTS = {{
+  {"materialWeightMg",      &EvalWeights::materialWeightMg},
+  {"materialWeightEg",      &EvalWeights::materialWeightEg},
+  {"pieceTableWeightMg",    &EvalWeights::pieceTableWeightMg},
+  {"pieceTableWeightEg",    &EvalWeights::pieceTableWeightEg},
+  {"pawnStructureWeightMg", &EvalWeights::pawnStructureWeightMg},
+  {"pawnStructureWeightEg", &EvalWeights::pawnStructureWeightEg},
+  {"mobilityWeightMg",      &EvalWeights::mobilityWeightMg},
+  {"threatsWeightMg",       &EvalWeights::threatsWeightMg},
+  {"distanceWeightEg",      &EvalWeights::distanceWeightEg}
+}};
+
+// Coordinate descent: probe each weight +-step, keep any move that lowers MSE; when a full
+// sweep yields no improvement, halve the step. Stops at a tiny step or the iteration cap.
+EvalWeights
+coordinateDescent(const vector<TuneEntry>& data, double K, EvalWeights best, int maxIters)
+{
+  // A sweep whose total MSE gain falls below this is treated as stalled at the current
+  // resolution, so the step shrinks (or the search ends once the step is tiny).
+  constexpr double STALL_GAIN = 1e-7;
+
+  double bestMse = meanSquaredError(data, K, best);
+  double step = 0.1;
+  int iter = 0;
+
+  while (step > 1e-3 && iter < maxIters)
+  {
+    const double sweepStart = bestMse;
+
+    for (const auto& wr : WEIGHTS)
+    {
+      const float orig = best.*wr.member;
+
+      best.*wr.member = orig + float(step);
+      double m = meanSquaredError(data, K, best);
+
+      if (m + 1e-12 < bestMse) { bestMse = m; continue; }
+
+      best.*wr.member = orig - float(step);
+      m = meanSquaredError(data, K, best);
+
+      if (m + 1e-12 < bestMse) { bestMse = m; continue; }
+
+      best.*wr.member = orig;  // neither direction helped; revert
+    }
+
+    ++iter;
+
+    if (sweepStart - bestMse < STALL_GAIN)
+    {
+      step *= 0.5;  // resolution exhausted; refine
+      cout << "  step " << std::fixed << std::setprecision(5) << step
+           << "  mse " << std::setprecision(8) << bestMse
+           << "  (" << iter << " sweeps)\n";
+    }
+  }
+
+  return best;
+}
+
+void
+printWeights(const EvalWeights& w)
+{
+  cout << std::fixed << std::setprecision(4);
+  for (const auto& wr : WEIGHTS)
+    cout << "  " << std::left << std::setw(24) << wr.name
+         << std::right << (w.*wr.member) << '\n';
+}
+
+}  // namespace
+
+void
+tuneEval(const vector<string>& args)
+{
+  cout << "\n--- Texel weight tuner ---\n";
+
+  if (!runSelfCheck())
+  {
+    cout << "Self-check FAILED: component reconstruction does not match evaluate(). "
+            "Aborting before tuning.\n";
+    return;
+  }
+
+  const string dataPath = utils::argValue(args, "data");
+  if (dataPath.empty())
+  {
+    cout << "No dataset given (use: elsa tune data <path.epd>). Self-check only.\n";
+    return;
+  }
+
+  const int maxIters = utils::hasArg(args, "iters")
+                     ? std::stoi(utils::argValue(args, "iters")) : 10000;
+
+  const perf_clock start = perf::now();
+  const vector<TuneEntry> data = loadDataset(dataPath);
+  if (data.empty()) { cout << "No tunable positions loaded. Aborting.\n"; return; }
+  const perf_time buildTime = perf::now() - start;
+  cout << "Cache built in " << std::fixed << std::setprecision(2)
+       << buildTime.count() << " s.\n\n";
+
+  EvalWeights start_w = evalWeights;
+  const double K = fitK(data, start_w);
+  const double mseBefore = meanSquaredError(data, K, start_w);
+  cout << "Fitted K = " << std::setprecision(4) << K
+       << "   MSE (defaults) = " << std::setprecision(8) << mseBefore << "\n\n";
+
+  cout << "Coordinate descent:\n";
+  const EvalWeights tuned = coordinateDescent(data, K, start_w, maxIters);
+  const double mseAfter = meanSquaredError(data, K, tuned);
+
+  cout << "\nMSE before = " << std::setprecision(8) << mseBefore
+       << "   MSE after = " << mseAfter
+       << "   (" << std::setprecision(4)
+       << 100.0 * (mseBefore - mseAfter) / mseBefore << "% lower)\n\n";
+
+  cout << "Default weights:\n"; printWeights(start_w);
+  cout << "Tuned weights:\n";   printWeights(tuned);
+  cout << "\nThese are NOT applied automatically — paste the values into EvalWeights "
+          "defaults if arena-validated.\n";
+}

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -1,5 +1,8 @@
 
 #include <fstream>
+#include <sstream>
+#include <filesystem>
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <array>
@@ -259,7 +262,7 @@ coordinateDescent(const vector<TuneEntry>& data, double K, EvalWeights best, int
       step *= 0.5;  // resolution exhausted; refine
       cout << "  step " << std::fixed << std::setprecision(5) << step
            << "  mse " << std::setprecision(8) << bestMse
-           << "  (" << iter << " sweeps)\n";
+           << "  (" << iter << " sweeps)" << endl;
     }
   }
 
@@ -267,12 +270,62 @@ coordinateDescent(const vector<TuneEntry>& data, double K, EvalWeights best, int
 }
 
 void
-printWeights(const EvalWeights& w)
+printWeights(std::ostream& os, const EvalWeights& w)
 {
-  cout << std::fixed << std::setprecision(4);
+  os << std::fixed << std::setprecision(4);
   for (const auto& wr : WEIGHTS)
-    cout << "  " << std::left << std::setw(24) << wr.name
-         << std::right << (w.*wr.member) << '\n';
+    os << "  " << std::left << std::setw(24) << wr.name
+       << std::right << (w.*wr.member) << '\n';
+}
+
+// Loads one dataset, fits K, runs coordinate descent, and streams the report to stdout.
+// When reportPath is non-empty the same default/tuned-weight block is also written there.
+// Returns false if the dataset could not be loaded (so --all can skip to the next file).
+bool
+tuneDataset(const string& path, int maxIters, const string& reportPath)
+{
+  const perf_clock start = perf::now();
+  const vector<TuneEntry> data = loadDataset(path);
+  if (data.empty()) { cout << "No tunable positions loaded. Skipping " << path << ".\n"; return false; }
+  const perf_time buildTime = perf::now() - start;
+  cout << "Cache built in " << std::fixed << std::setprecision(2)
+       << buildTime.count() << " s.\n\n";
+
+  EvalWeights start_w = evalWeights;
+  const double K = fitK(data, start_w);
+  const double mseBefore = meanSquaredError(data, K, start_w);
+  cout << "Fitted K = " << std::setprecision(4) << K
+       << "   MSE (defaults) = " << std::setprecision(8) << mseBefore << "\n\n";
+
+  cout << "Coordinate descent:\n";
+  const EvalWeights tuned = coordinateDescent(data, K, start_w, maxIters);
+  const double mseAfter = meanSquaredError(data, K, tuned);
+
+  // Build the result block once, then send it to stdout and (optionally) the report file.
+  std::ostringstream report;
+  report << "Dataset: " << path << '\n'
+         << "Fitted K = " << std::fixed << std::setprecision(4) << K << '\n'
+         << "MSE before = " << std::setprecision(8) << mseBefore
+         << "   MSE after = " << mseAfter
+         << "   (" << std::setprecision(4)
+         << 100.0 * (mseBefore - mseAfter) / mseBefore << "% lower)\n\n"
+         << "Default weights:\n";
+  printWeights(report, start_w);
+  report << "Tuned weights:\n";
+  printWeights(report, tuned);
+
+  cout << '\n' << report.str();
+
+  if (!reportPath.empty())
+  {
+    std::ofstream f(reportPath);
+    if (f) { f << report.str(); cout << "  -> wrote " << reportPath << '\n'; }
+    else   { cout << "  ! could not write " << reportPath << '\n'; }
+  }
+
+  cout << "\nThese are NOT applied automatically — paste the values into EvalWeights "
+          "defaults if arena-validated.\n";
+  return true;
 }
 
 }  // namespace
@@ -289,40 +342,58 @@ tuneEval(const vector<string>& args)
     return;
   }
 
-  const string dataPath = utils::argValue(args, "data");
-  if (dataPath.empty())
-  {
-    cout << "No dataset given (use: elsa tune data <path.epd>). Self-check only.\n";
-    return;
-  }
-
   const int maxIters = utils::hasArg(args, "iters")
                      ? std::stoi(utils::argValue(args, "iters")) : 10000;
 
-  const perf_clock start = perf::now();
-  const vector<TuneEntry> data = loadDataset(dataPath);
-  if (data.empty()) { cout << "No tunable positions loaded. Aborting.\n"; return; }
-  const perf_time buildTime = perf::now() - start;
-  cout << "Cache built in " << std::fixed << std::setprecision(2)
-       << buildTime.count() << " s.\n\n";
+  // --all: tune every *.epd in the dataset directory in turn, writing each result to
+  // its own tune_<stem>.txt alongside the stdout report. Directory defaults to the
+  // texel_dataset folder (relative to the usual output/ working dir); override with
+  // `dir <path>`.
+  if (utils::hasArg(args, "--all") || utils::hasArg(args, "all"))
+  {
+    namespace fs = std::filesystem;
+    const string dirArg = utils::argValue(args, "dir");
+    const fs::path dir = dirArg.empty() ? fs::path("../Utility/texel_dataset") : fs::path(dirArg);
 
-  EvalWeights start_w = evalWeights;
-  const double K = fitK(data, start_w);
-  const double mseBefore = meanSquaredError(data, K, start_w);
-  cout << "Fitted K = " << std::setprecision(4) << K
-       << "   MSE (defaults) = " << std::setprecision(8) << mseBefore << "\n\n";
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec))
+    {
+      cout << "Dataset directory not found: " << dir.string()
+           << " (override with: elsa tune --all dir <path>)\n";
+      return;
+    }
 
-  cout << "Coordinate descent:\n";
-  const EvalWeights tuned = coordinateDescent(data, K, start_w, maxIters);
-  const double mseAfter = meanSquaredError(data, K, tuned);
+    vector<fs::path> datasets;
+    for (const auto& entry : fs::directory_iterator(dir))
+      if (entry.is_regular_file() && entry.path().extension() == ".epd")
+        datasets.push_back(entry.path());
+    std::sort(datasets.begin(), datasets.end());
 
-  cout << "\nMSE before = " << std::setprecision(8) << mseBefore
-       << "   MSE after = " << mseAfter
-       << "   (" << std::setprecision(4)
-       << 100.0 * (mseBefore - mseAfter) / mseBefore << "% lower)\n\n";
+    if (datasets.empty()) { cout << "No .epd files in " << dir.string() << '\n'; return; }
 
-  cout << "Default weights:\n"; printWeights(start_w);
-  cout << "Tuned weights:\n";   printWeights(tuned);
-  cout << "\nThese are NOT applied automatically — paste the values into EvalWeights "
-          "defaults if arena-validated.\n";
+    cout << "Tuning across " << datasets.size() << " dataset(s) in " << dir.string() << ":\n";
+    for (const auto& p : datasets) cout << "  - " << p.filename().string() << '\n';
+
+    size_t idx = 0;
+    for (const auto& p : datasets)
+    {
+      ++idx;
+      cout << "\n================ [" << idx << '/' << datasets.size() << "] "
+           << p.filename().string() << " ================\n";
+      const string reportPath = "tune_" + p.stem().string() + ".txt";
+      tuneDataset(p.string(), maxIters, reportPath);
+    }
+    cout << "\nAll datasets done.\n";
+    return;
+  }
+
+  const string dataPath = utils::argValue(args, "data");
+  if (dataPath.empty())
+  {
+    cout << "No dataset given (use: elsa tune data <path.epd>, or elsa tune --all). "
+            "Self-check only.\n";
+    return;
+  }
+
+  tuneDataset(dataPath, maxIters, "");
 }

--- a/src/tuner.h
+++ b/src/tuner.h
@@ -1,0 +1,21 @@
+
+#ifndef TUNER_H
+#define TUNER_H
+
+#include <vector>
+#include <string>
+
+// Texel-style evaluation weight tuner.
+//
+//   elsa tune [data <path>] [iters <n>]
+//
+// With no `data` path it only runs the correctness self-check (the reconstruction
+// from cached components must reproduce the real white-relative static eval). With a
+// labeled dataset it fits the sigmoid scaling constant K, then coordinate-descends the
+// runtime EvalWeights to minimise mean-squared prediction error, printing the MSE
+// before/after and the tuned weights. It does NOT overwrite the engine's defaults —
+// the tuned values are printed for the user to paste in deliberately.
+void
+tuneEval(const std::vector<std::string>& args);
+
+#endif


### PR DESCRIPTION
## Summary
- Runtime-tunable `EvalWeights` (9 mg/eg weights) + cached white-relative
  per-component subtotals so each tuner iteration is pure arithmetic.
- `elsa tune` / `elsa tune --all` subcommand: K-fit via ternary search +
  coordinate descent with step halving over the 9 weights.
- First arena-validated weight change:
    pawnStructureWeightMg  0.40 -> 0.15
    mobilityWeightMg       1.20 -> 2.20
    threatsWeightMg        0.50 -> 0.70

## Result
1000 games at 1s+0.1s in the Chessmate arena: **545.5 - 454.5
(W 412 / D 267 / L 321) = +32 Elo** vs prior master.
