### PR TITLE
Shallow-node static-eval pruning: RFP + razoring + quiet-move futility (+112 Elo)

### DIFF
--- a/src/node_state.h
+++ b/src/node_state.h
@@ -22,6 +22,10 @@ struct NodeState
   int numExtensions;
   Flag hashf = Flag::HASH_ALPHA;
 
+  // Node static eval, computed at most once per node (lazy) and reused across
+  // RFP / razoring / futility / improving. nullopt until first requested.
+  std::optional<Score> staticEval = std::nullopt;
+
   constexpr int pvNextIndex() const noexcept { return pvIndex + MAX_PLY - ply; }
 };
 

--- a/src/node_state.h
+++ b/src/node_state.h
@@ -26,6 +26,11 @@ struct NodeState
   // RFP / razoring / futility / improving. nullopt until first requested.
   std::optional<Score> staticEval = std::nullopt;
 
+  // Quiet-move futility flag, set in alphaBeta when the node's static eval sits
+  // a depth-scaled margin below alpha. Consumed in the QUIET stage of
+  // playSubsetMoves to skip the residual quiet moves once one move is searched.
+  bool quietFutile = false;
+
   constexpr int pvNextIndex() const noexcept { return pvIndex + MAX_PLY - ply; }
 };
 

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -361,6 +361,33 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
     }
   }
 
+  // Razoring: alpha-side mirror of RFP. At a shallow, not-in-check node whose
+  // static eval sits a depth-scaled margin *below* alpha, the node looks
+  // hopeless on the alpha side. Rather than trust the static eval blindly,
+  // verify with a quiescence search (it resolves hanging captures the static
+  // eval missed); only if qsearch still fails low (<= alpha) do we return that
+  // fail-soft score instead of a full-width search. If qsearch beats alpha the
+  // node wasn't hopeless after all — fall through. Eval reuses the RFP cache
+  // (nodeStaticEval computes at most once per node). Like RFP: no TT store,
+  // bestMove untouched, so the fail-low TT-hint/LMR gotcha does not apply.
+  if constexpr (USE_RAZOR)
+  {
+    if (myMoves.checkers == 0
+      and depth <= RAZOR_MAX_DEPTH
+      and __abs(alpha) < VALUE_MATE - MAX_PLY * 20)
+    {
+      const Score staticEval = nodeStaticEval(pos, ns);
+      if (staticEval + RAZOR_MARGIN * depth <= alpha)
+      {
+        const Score razorScore = quiescenceSearch<1>(pos, alpha, beta, ply, pvIndex);
+        if (info.timeOver())
+          return TIMEOUT;
+        if (razorScore <= alpha)
+          return razorScore;
+      }
+    }
+  }
+
   stagedGenerateMoves<GEN_MOVES   >(pos, myMoves);
 
   if (!myMoves.anyMove())

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -201,7 +201,7 @@ static Move
 playSubsetMoves(
   ChessBoard& pos, const MoveList& myMoves, MoveArray& movesArray,
   size_t start, size_t end,
-  NodeState& ns, Move bestMove
+  NodeState& ns, Move bestMove, bool futilityStage = false
 )
 {
   // myMoves.removedMoves() accounts for moves searched *outside* this array
@@ -214,6 +214,18 @@ playSubsetMoves(
   for (size_t moveNo = start; moveNo < end; ++moveNo)
   {
     Move move = movesArray[moveNo];
+
+    // Quiet-move futility: at a shallow, not-in-check node whose static eval
+    // sits a depth-scaled margin below alpha (ns.quietFutile, computed in
+    // alphaBeta), the residual quiet moves are very unlikely to raise it. Once
+    // at least one move has been searched (bestMove set — so the fail-low
+    // return is backed by a real score), skip the rest. This is reached with
+    // futilityStage == true only for the QUIET residual (captures / promotions
+    // / checks / PV / killers ran in earlier stages), so every move here is
+    // already quiet & non-check — no per-move type test needed. Unverified bet
+    // (cf. razoring's qsearch check); the depth-scaled margin is the safety.
+    if (futilityStage and ns.quietFutile and bestMove != NULL_MOVE)
+      break;
 
     // HASH_ALPHA fallback: remember the first searched move at this node so
     // the TT entry has *something* to suggest on a fail-low revisit.
@@ -271,7 +283,10 @@ playAllMoves(
     ? movesArray.size()
     : orderMoves(pos, movesArray, orderType, ns.ply, start);
 
-  bestMove = playSubsetMoves(pos, myMoves, movesArray, start, end, ns, bestMove);
+  // Only the residual QUIET stage may futility-prune; earlier stages (captures,
+  // promotions, checks, PV, killers) always search their moves.
+  bestMove = playSubsetMoves(pos, myMoves, movesArray, start, end, ns, bestMove,
+                             orderType == MType::QUIET);
 
   if (ns.hashf == Flag::HASH_BETA)
     return bestMove;
@@ -402,6 +417,27 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
     numExtensions += extensions;
     ns.depth = depth;
     ns.numExtensions = numExtensions;
+  }
+
+  // Quiet-move futility precondition (consumed in the QUIET stage of
+  // playAllMoves -> playSubsetMoves). At a shallow, not-in-check node outside
+  // the mate window whose static eval sits a depth-scaled margin below alpha,
+  // the residual quiet moves are very unlikely to raise it. We only *flag* it
+  // here; the actual skip happens per-move, after >=1 move is searched, so the
+  // fail-low return stays backed by a real score. depth is post-extension
+  // (an extended = interesting node gets a larger depth/margin -> futility
+  // fires less). nodeStaticEval reuses the RFP/razoring cache, so this adds no
+  // eval cost at depth <= RFP_MAX_DEPTH (RFP already computed it for non-check
+  // nodes). No TT/bestMove effect — like RFP/razoring, the LMR gotcha is N/A.
+  if constexpr (USE_FUTILITY)
+  {
+    if (myMoves.checkers == 0
+      and depth <= FUTILITY_MAX_DEPTH
+      and __abs(alpha) < VALUE_MATE - MAX_PLY * 20)
+    {
+      const Score staticEval = nodeStaticEval(pos, ns);
+      ns.quietFutile = (staticEval + FUTILITY_MARGIN * depth <= alpha);
+    }
   }
 
   pvArray[pvIndex] = NULL_MOVE;

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -282,6 +282,17 @@ playAllMoves(
   return bestMove;
 }
 
+// Lazily compute and cache the node's static evaluation. Multiple search
+// heuristics (RFP today; razoring / futility / improving later) want the same
+// value — compute it at most once per node and reuse it from NodeState.
+static inline Score
+nodeStaticEval(ChessBoard& pos, NodeState& ns)
+{
+  if (!ns.staticEval.has_value())
+    ns.staticEval = evaluate(pos);
+  return *ns.staticEval;
+}
+
 Score
 alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions)
 {
@@ -324,20 +335,29 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   MoveList myMoves;
   stagedGenerateMoves<GEN_METADATA>(pos, myMoves);
 
+  // Per-node search state. Built here, before RFP, so the node's static eval
+  // can be cached in it once (via nodeStaticEval) and reused by every
+  // heuristic in the node. depth / numExtensions are pre-extension at this
+  // point — synced into ns after the extension policy runs below.
+  NodeState ns{alpha, beta, depth, ply, pvIndex, numExtensions};
+
   // Reverse futility pruning: at a shallow, not-in-check node, if the static
   // eval already beats beta by a depth-scaled margin, assume some move holds
-  // the cutoff and return without generating/searching moves. evaluate() is
-  // computed lazily — only when the cheap gates (not in check, shallow depth,
-  // non-mate window) pass. Fail-hard return; no TT store on the prune.
+  // the cutoff and return without generating/searching moves. nodeStaticEval()
+  // is computed lazily — only when the cheap gates (not in check, shallow
+  // depth, non-mate window) pass. Fail-soft return: staticEval (>= beta, since
+  // staticEval - margin*depth >= beta) hands the parent a truer lower bound
+  // than a flat beta. No TT store on the prune; bestMove untouched, so the
+  // fail-low TT-hint/LMR gotcha (best-move semantics) does not apply here.
   if constexpr (USE_RFP)
   {
     if (myMoves.checkers == 0
       and depth <= RFP_MAX_DEPTH
       and __abs(beta) < VALUE_MATE - MAX_PLY * 20)
     {
-      const Score staticEval = evaluate(pos);
+      const Score staticEval = nodeStaticEval(pos, ns);
       if (staticEval - RFP_MARGIN * depth >= beta)
-        return beta;
+        return staticEval;
     }
   }
 
@@ -353,11 +373,12 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
     int extensions = searchExtension(pos, myMoves, numExtensions, depth);
     depth += extensions;
     numExtensions += extensions;
+    ns.depth = depth;
+    ns.numExtensions = numExtensions;
   }
 
   pvArray[pvIndex] = NULL_MOVE;
 
-  NodeState ns{alpha, beta, depth, ply, pvIndex, numExtensions};
   Move bestMove = NULL_MOVE;
 
   HashMoveOutcome hashOutcome = playHashMove(pos, hashMove, ns, bestMove);

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -323,6 +323,24 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   // skips it (and all of orderMoves/staging) entirely.
   MoveList myMoves;
   stagedGenerateMoves<GEN_METADATA>(pos, myMoves);
+
+  // Reverse futility pruning: at a shallow, not-in-check node, if the static
+  // eval already beats beta by a depth-scaled margin, assume some move holds
+  // the cutoff and return without generating/searching moves. evaluate() is
+  // computed lazily — only when the cheap gates (not in check, shallow depth,
+  // non-mate window) pass. Fail-hard return; no TT store on the prune.
+  if constexpr (USE_RFP)
+  {
+    if (myMoves.checkers == 0
+      and depth <= RFP_MAX_DEPTH
+      and __abs(beta) < VALUE_MATE - MAX_PLY * 20)
+    {
+      const Score staticEval = evaluate(pos);
+      if (staticEval - RFP_MARGIN * depth >= beta)
+        return beta;
+    }
+  }
+
   stagedGenerateMoves<GEN_MOVES   >(pos, myMoves);
 
   if (!myMoves.anyMove())

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,7 @@ enum SearchFlag: bool
   USE_LMR = true,
   USE_EXTENSIONS = true,
   USE_MOVE_ORDER = true,
+  USE_RFP = true,
 };
 
 enum Color: uint8_t
@@ -59,6 +60,7 @@ enum Search
   MAX_DEPTH = 36,
   LMR_LIMIT = 4,
   EXTENSION_LIMIT = 8,
+  RFP_MAX_DEPTH = 6,
   TIMEOUT = 1112223334,
   DEFAULT_SEARCH_TIME = 1,
   MAX_THREADS = 12,
@@ -93,6 +95,7 @@ enum Value: Score
   VALUE_INF  = 16001,
   VALUE_UNKNOWN = 555666777,
   VALUE_WINDOW = 4,
+  RFP_MARGIN = 110,
   VALUE_TRANSPOSITION_TABLE_SEED = 1557,
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -26,6 +26,7 @@ enum SearchFlag: bool
   USE_MOVE_ORDER = true,
   USE_RFP = true,
   USE_RAZOR = true,
+  USE_FUTILITY = true,
 };
 
 enum Color: uint8_t
@@ -63,6 +64,7 @@ enum Search
   EXTENSION_LIMIT = 8,
   RFP_MAX_DEPTH = 6,
   RAZOR_MAX_DEPTH = 3,
+  FUTILITY_MAX_DEPTH = 4,
   TIMEOUT = 1112223334,
   DEFAULT_SEARCH_TIME = 1,
   MAX_THREADS = 12,
@@ -99,6 +101,7 @@ enum Value: Score
   VALUE_WINDOW = 4,
   RFP_MARGIN = 110,
   RAZOR_MARGIN = 240,
+  FUTILITY_MARGIN = 120,
   VALUE_TRANSPOSITION_TABLE_SEED = 1557,
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -25,6 +25,7 @@ enum SearchFlag: bool
   USE_EXTENSIONS = true,
   USE_MOVE_ORDER = true,
   USE_RFP = true,
+  USE_RAZOR = true,
 };
 
 enum Color: uint8_t
@@ -61,6 +62,7 @@ enum Search
   LMR_LIMIT = 4,
   EXTENSION_LIMIT = 8,
   RFP_MAX_DEPTH = 6,
+  RAZOR_MAX_DEPTH = 3,
   TIMEOUT = 1112223334,
   DEFAULT_SEARCH_TIME = 1,
   MAX_THREADS = 12,
@@ -96,6 +98,7 @@ enum Value: Score
   VALUE_UNKNOWN = 555666777,
   VALUE_WINDOW = 4,
   RFP_MARGIN = 110,
+  RAZOR_MARGIN = 240,
   VALUE_TRANSPOSITION_TABLE_SEED = 1557,
 
 


### PR DESCRIPTION
Adds a chain of shallow-node prunes sharing one cached per-node static eval.
Cumulative **+112.7 Elo** over master (3000g @ 1s+0.1s); each validated solo:

- **Reverse futility pruning** (beta side) — **+50 Elo**
- **Razoring** (alpha side, quiescence-verified) — **+32 Elo**
- **Quiet-move futility** — **+26 Elo**
- Fail-soft RFP — neutral, kept as the cached-eval enabler

