### PR TITLE
Null-move pruning (+18 Elo)

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -571,19 +571,33 @@ ChessBoard::generateHashkey() const
 void
 ChessBoard::makeNullMove()
 {
-  csep = (csep & 1920) ^ 64;
-  // hashValue ^= TT.HashIndex[0];
+  // Save full state so unmakeNullMove can restore it verbatim. A null move is
+  // never irreversible, so (unlike undoInfoPush) we never reset the stack.
+  undoInfo[undoInfoStackCounter++] = UndoInfo(NULL_MOVE, csep, hashValue, halfmove);
+
+  if constexpr (USE_TT) {
+    // An en-passant target cannot survive a null move — drop it from the hash
+    // before csep is cleared (read while csep still holds the old value).
+    if (enPassantSquare() != SQUARE_NB)
+      hashValue ^= tt.hashKey(enPassantSquare() + 1);
+
+    // Flip side-to-move in the hash, mirroring every real move (hashKey(0)).
+    hashValue ^= tt.hashKey(0);
+  }
+
+  // Reset en-passant state (keep castling bits), then flip side to move.
+  csep = (csep & 1920) ^ SQUARE_NB;
   color = ~color;
 }
 
 void
 ChessBoard::unmakeNullMove()
 {
-  // Update to not use t_csep form external source
-  // csep = t_csep;
-  // Hash_Value ^= TT.HashIndex[0];
   color = ~color;
-  // moveInvert(0, t_csep, t_HashVal);
+  undoInfoStackCounter--;
+  csep      = undoInfo[undoInfoStackCounter].csep;
+  hashValue = undoInfo[undoInfoStackCounter].hash;
+  halfmove  = undoInfo[undoInfoStackCounter].halfmove;
 }
 
 void

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -553,15 +553,13 @@ ChessBoard::makeNullMove()
   // never irreversible, so (unlike undoInfoPush) we never reset the stack.
   undoInfo[undoInfoStackCounter++] = UndoInfo(NULL_MOVE, csep, hashValue, halfmove);
 
-  if constexpr (USE_TT) {
-    // An en-passant target cannot survive a null move — drop it from the hash
-    // before csep is cleared (read while csep still holds the old value).
-    if (enPassantSquare() != SQUARE_NB)
-      hashValue ^= tt.hashKey(enPassantSquare() + 1);
+  // An en-passant target cannot survive a null move — drop it from the hash
+  // before csep is cleared (read while csep still holds the old value).
+  if (enPassantSquare() != SQUARE_NB)
+    hashValue ^= tt.hashKey(enPassantSquare() + 1);
 
-    // Flip side-to-move in the hash, mirroring every real move (hashKey(0)).
-    hashValue ^= tt.hashKey(0);
-  }
+  // Flip side-to-move in the hash, mirroring every real move (hashKey(0)).
+  hashValue ^= tt.hashKey(0);
 
   // Reset en-passant state (keep castling bits), then flip side to move.
   csep = (csep & 1920) ^ SQUARE_NB;

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -182,6 +182,12 @@ class ChessBoard
   getPiece(Color c, PieceType pt) const noexcept
   { return pieceBb[make_piece(c, pt)]; }
 
+  // NMP zugzwang guard: at least one non-pawn, non-king piece for `c`.
+  bool
+  hasNonPawnMaterial(Color c) const noexcept
+  { return pieceCt[make_piece(c, KNIGHT)] + pieceCt[make_piece(c, BISHOP)]
+         + pieceCt[make_piece(c, ROOK)]   + pieceCt[make_piece(c, QUEEN)] > 0; }
+
   constexpr Bitboard
   all() const noexcept
   { return pieceBb[make_piece(WHITE, ALL)] | pieceBb[make_piece(BLACK, ALL)]; }

--- a/src/search_utils.cpp
+++ b/src/search_utils.cpp
@@ -28,6 +28,14 @@ checkmateScore(Ply ply)
 { return -VALUE_MATE + (20 * ply); }
 
 bool
+isMateScore(Score score)
+{ return __abs(score) >= int(VALUE_MATE) - int(MAX_PLY); }
+
+int
+nullReduction(Depth depth)
+{ return 3 + depth / 4; }
+
+bool
 lmrOk(Move move, Depth depth, size_t moveNo)
 {
   if ((depth < 2) or (moveNo < LMR_LIMIT) or interestingMove(move))

--- a/src/search_utils.h
+++ b/src/search_utils.h
@@ -20,6 +20,15 @@ clearKillers();
 Score
 checkmateScore(Ply ply);
 
+// True when a score lies in the mate range (mate-in-N is encoded as
+// VALUE_MATE - 20*ply, so anything within MAX_PLY of VALUE_MATE is a mate).
+bool
+isMateScore(Score score);
+
+// Null-move search depth reduction for the given remaining depth.
+int
+nullReduction(Depth depth);
+
 template <MType mt>
 inline bool
 is_type(Move m)

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -278,7 +278,7 @@ playAllMoves(
 }
 
 Score
-alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions)
+alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions, bool doNull)
 {
   if (info.timeOver())
     return TIMEOUT;
@@ -325,6 +325,38 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
 
   if (!myMoves.exists<MType::CAPTURES>(pos) and isTheoreticalDraw(pos))
     return VALUE_DRAW;
+
+  // --- Null-move pruning (NMP) ---
+  // Hand the opponent a free tempo and search their reply at reduced depth
+  // with a null window around beta. If they still can't pull our score below
+  // beta, a real move almost certainly fails high too — so prune. Uses the
+  // pre-extension depth and the already-populated myMoves.checkers.
+  if constexpr (USE_NMP)
+  {
+    if (doNull
+        and myMoves.checkers == 0                 // never null out of check
+        and depth >= NMP_MIN_DEPTH                 // too shallow to be worth it
+        and !isMateScore(beta)                     // don't manufacture false mates
+        and pos.hasNonPawnMaterial(pos.color))     // zugzwang guard
+    {
+      const int R = nullReduction(depth);
+      const int rawNullDepth = depth - 1 - R;
+      const Depth nullDepth = static_cast<Depth>(rawNullDepth > 0 ? rawNullDepth : 0);
+      const int pvNextIndex = pvIndex + MAX_PLY - ply;
+
+      pos.makeNullMove();
+      Score nullScore = -alphaBeta(pos, nullDepth, -beta, -beta + 1,
+                                   ply + 1, pvNextIndex, numExtensions,
+                                   /*doNull=*/false);
+      pos.unmakeNullMove();
+
+      if (info.timeOver())
+        return TIMEOUT;
+
+      if (nullScore >= beta)
+        return isMateScore(nullScore) ? beta : nullScore;
+    }
+  }
 
   if constexpr (USE_EXTENSIONS) {
     int extensions = searchExtension(pos, myMoves, numExtensions, depth);

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -435,7 +435,7 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
                                    /*doNull=*/false);
       pos.unmakeNullMove();
 
-      if (info.timeOver())
+      if (info.shouldStop())
         return TIMEOUT;
 
       if (nullScore >= beta)

--- a/src/single_thread.h
+++ b/src/single_thread.h
@@ -47,7 +47,7 @@ search(
  * @return Score 
  */
 Score
-alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions);
+alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions, bool doNull = true);
 
 
 Score

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,7 @@ enum SearchFlag: bool
   USE_LMR = true,
   USE_EXTENSIONS = true,
   USE_MOVE_ORDER = true,
+  USE_NMP = true,
 };
 
 enum Color: uint8_t
@@ -59,6 +60,7 @@ enum Search
   MAX_DEPTH = 36,
   LMR_LIMIT = 4,
   EXTENSION_LIMIT = 8,
+  NMP_MIN_DEPTH = 3,
   VAL_WINDOW = 16,
   TIMEOUT = 1112223334,
   DEFAULT_SEARCH_TIME = 1,


### PR DESCRIPTION
Adds null-move pruning on top of the shallow-node pruning suite. At a
non-PV-ish node the side to move forfeits a tempo and the opponent's reply is
searched at reduced depth with a null window around beta; if they still can't
pull the score below beta, a real move almost certainly fails high too, so the
node is pruned.

Also promotes `makeNullMove`/`unmakeNullMove` from the stub primitives on master
to full implementations — undo-stack save/restore plus hash maintenance (drop
the en-passant target, flip side-to-move), so the null child hashes and detects
repetitions correctly.

- Reduction `R = 3 + depth/4`; null-window scout `[-beta, -beta+1]`
- Guards: not in check, `depth >= NMP_MIN_DEPTH` (3), non-mate beta, and
  `hasNonPawnMaterial` (zugzwang guard)
- `doNull=false` in the null child to forbid back-to-back nulls
- Abort gate routes through `shouldStop()` so async UCI `stop` is honored

## Arena results

2511 games at 1s + 0.1s vs `master`: **945W / 754D / 812L → 52.65% → +18 Elo**
(95% CI ≈ [+7, +30], excludes 0).
