### PR TITLE
add bishop-pair, rook-open-file & isolated-pawn terms (+43 elo)

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -259,6 +259,58 @@ threats(const ChessBoard& pos)
 
 #ifndef MIDGAME
 
+// Smear a bitboard so every occupied file is fully set (standard file-fill).
+static Bitboard
+fileFill(Bitboard b)
+{
+  b |= b >> 8;  b |= b << 8;
+  b |= b >> 16; b |= b << 16;
+  b |= b >> 32; b |= b << 32;
+  return b;
+}
+
+// +1 if White has the bishop pair, -1 if Black does, 0 otherwise.
+static int
+bishopPairDiff(const ChessBoard& pos)
+{
+  return int(pos.count<WHITE, BISHOP>() >= 2)
+       - int(pos.count<BLACK, BISHOP>() >= 2);
+}
+
+// Rook-file "units": +2 per rook on a fully-open file, +1 per semi-open file.
+template <Color cMy>
+static Score
+rookFileUnits(const ChessBoard& pos)
+{
+  Bitboard rooks    = pos.piece<cMy, ROOK>();
+  Bitboard myPawns  = pos.piece<cMy, PAWN>();
+  Bitboard allPawns = pos.piece<WHITE, PAWN>() | pos.piece<BLACK, PAWN>();
+  Score units = 0;
+
+  while (rooks != 0)
+  {
+    Square sq = nextSquare(rooks);
+    Bitboard file = FileA << (sq & 7);
+
+    if      ((file & allPawns) == 0) units += 2;  // open
+    else if ((file & myPawns)  == 0) units += 1;  // semi-open
+  }
+
+  return units;
+}
+
+// Count of pawns with no friendly pawn on either adjacent file.
+template <Color cMy>
+static int
+isolatedPawnCount(const ChessBoard& pos)
+{
+  Bitboard pawns     = pos.piece<cMy, PAWN>();
+  Bitboard files     = fileFill(pawns);
+  Bitboard neighbors = ((files & ~Bitboard(FileH)) << 1)
+                     | ((files & ~Bitboard(FileA)) >> 1);
+  return popCount(pawns & ~neighbors);
+}
+
 static Score
 materialDiffereceMidGame(const ChessBoard& pos)
 {
@@ -394,6 +446,10 @@ midGameScore(const ChessBoard& pos, float /*phase*/)
                         - pawnStructureScoreMidgame<BLACK>(pos);
   Score threatsScore    = threats<debug>(pos);
 
+  int   bishopPair = bishopPairDiff(pos);
+  Score rookFile   = rookFileUnits<WHITE>(pos) - rookFileUnits<BLACK>(pos);
+  int   isolated   = isolatedPawnCount<WHITE>(pos) - isolatedPawnCount<BLACK>(pos);
+
   if (debug)
   {
     cout << "-------------------- MIDGAME --------------------\n"
@@ -405,6 +461,9 @@ midGameScore(const ChessBoard& pos, float /*phase*/)
       << "\nmobQueen        = " << mob.queen
       << "\npawnStructure   = " << pawnStructure
       << "\nthreatsScore    = " << threatsScore
+      << "\nbishopPair      = " << bishopPair
+      << "\nrookFile        = " << rookFile
+      << "\nisolated        = " << isolated
       << "\n-------------------------------------------------" << endl;
   }
 
@@ -413,7 +472,10 @@ midGameScore(const ChessBoard& pos, float /*phase*/)
     + evalWeights.pieceTableWeightMg    * float(pieceTableScore)
     + mob.weighted(evalWeights)
     + evalWeights.pawnStructureWeightMg * float(pawnStructure)
-    + evalWeights.threatsWeightMg       * float(threatsScore);
+    + evalWeights.threatsWeightMg       * float(threatsScore)
+    + evalWeights.bishopPairWeightMg    * float(bishopPair)
+    + evalWeights.rookFileWeightMg      * float(rookFile)
+    + evalWeights.isolatedPawnWeightMg  * float(isolated);
 
   return Score(eval);
 }
@@ -587,6 +649,9 @@ endGameScore(const ChessBoard& pos, const EvalData& ed, float /*phase*/)
                         - pawnStructureScoreEndgame<BLACK>(pos, ed);
   Score distanceScore   = distanceBetweenKingsScore(pos);
 
+  int bishopPair = bishopPairDiff(pos);
+  int isolated   = isolatedPawnCount<WHITE>(pos) - isolatedPawnCount<BLACK>(pos);
+
   if (debug)
   {
     cout << "-------------------- ENDGAME --------------------\n"
@@ -594,6 +659,8 @@ endGameScore(const ChessBoard& pos, const EvalData& ed, float /*phase*/)
       << "\npieceTableScore    = " << pieceTableScore
       << "\npawnStructureScore = " << pawnStructure
       << "\ndistanceScore      = " << distanceScore
+      << "\nbishopPair         = " << bishopPair
+      << "\nisolated           = " << isolated
       << "\n-------------------------------------------------" << endl;
   }
 
@@ -601,7 +668,9 @@ endGameScore(const ChessBoard& pos, const EvalData& ed, float /*phase*/)
       evalWeights.materialWeightEg      * float(materialScore)
     + evalWeights.pieceTableWeightEg    * float(pieceTableScore)
     + evalWeights.pawnStructureWeightEg * float(pawnStructure)
-    + evalWeights.distanceWeightEg      * float(distanceScore);
+    + evalWeights.distanceWeightEg      * float(distanceScore)
+    + evalWeights.bishopPairWeightEg    * float(bishopPair)
+    + evalWeights.isolatedPawnWeightEg  * float(isolated);
 
   return Score(eval);
 }
@@ -715,6 +784,10 @@ extractEvalComponents(const ChessBoard& pos)
               - pawnStructureScoreEndgame<BLACK>(pos, ed));
   ec.distance = float(distanceBetweenKingsScore(pos));
 
+  ec.bishopPair = float(bishopPairDiff(pos));
+  ec.rookFileMg = float(rookFileUnits<WHITE>(pos) - rookFileUnits<BLACK>(pos));
+  ec.isolated   = float(isolatedPawnCount<WHITE>(pos) - isolatedPawnCount<BLACK>(pos));
+
   return ec;
 }
 
@@ -728,13 +801,18 @@ evalFromComponents(const EvalComponents& ec, const EvalWeights& w)
     + w.pieceTableWeightMg    * ec.ptMg
     + mob.weighted(w)
     + w.pawnStructureWeightMg * ec.pawnMg
-    + w.threatsWeightMg       * ec.threats;
+    + w.threatsWeightMg       * ec.threats
+    + w.bishopPairWeightMg    * ec.bishopPair
+    + w.rookFileWeightMg      * ec.rookFileMg
+    + w.isolatedPawnWeightMg  * ec.isolated;
 
   float eg =
       w.materialWeightEg      * ec.matEg
     + w.pieceTableWeightEg    * ec.ptEg
     + w.pawnStructureWeightEg * ec.pawnEg
-    + w.distanceWeightEg      * ec.distance;
+    + w.distanceWeightEg      * ec.distance
+    + w.bishopPairWeightEg    * ec.bishopPair
+    + w.isolatedPawnWeightEg  * ec.isolated;
 
   // Match evaluate(): mg/eg are truncated to Score (int32) before the phase blend.
   Score mgScore = Score(mg);

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -70,6 +70,14 @@ struct EvalWeights
 	float mobQueenWeightMg      = 4.5f;  // midgame-only
 	float threatsWeightMg       = 0.7f;  // midgame-only
 	float distanceWeightEg      = 1.0f;  // endgame-only king-distance term
+	// --- eval batch (bishop pair / rook-file / isolated pawns), Texel-tuned 2026-07-12 ---
+	// Cross-dataset unanimous signal; adopted low-end of each range (rookFile tempered
+	// below tuned ~23 to offset overlap with the standing rook-mobility term).
+	float bishopPairWeightMg    =  40.0f;
+	float bishopPairWeightEg    =  55.0f;  // pair worth more in open endgames
+	float rookFileWeightMg      =  16.0f;  // x units: open~32cp, semi-open~16cp (mg-only)
+	float isolatedPawnWeightMg  = -16.0f;  // penalty; weight carries the sign
+	float isolatedPawnWeightEg  =  -4.0f;  // tuner: eg isolani much milder than mg
 };
 
 extern EvalWeights evalWeights;
@@ -96,6 +104,9 @@ struct EvalComponents
 	// 2x knight bake-in) so the tuner sees an unbiased per-piece subtotal.
 	float matMg = 0.0f, ptMg = 0.0f, pawnMg = 0.0f, threats = 0.0f;
 	float mobBishop = 0.0f, mobKnight = 0.0f, mobRook = 0.0f, mobQueen = 0.0f;
+	// eval batch: bishopPair (-1/0/+1) and isolated (whiteIso-blackIso) feed BOTH
+	// phases; rookFileMg is mg-only. All white-relative unit diffs.
+	float bishopPair = 0.0f, rookFileMg = 0.0f, isolated = 0.0f;
 	// endgame components; pawnEg is the endgame pawn-structure subtotal
 	// (passers / king-escort / safe-promote + doubled), distinct from the midgame
 	// pawnMg (doubled-pawn penalty only)

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -206,10 +206,10 @@ fitK(const vector<TuneEntry>& data, const EvalWeights& w)
   return (lo + hi) / 2.0;
 }
 
-// The 12 tunable weights, exposed as named handles into a weight set for coordinate descent.
+// The tunable weights, exposed as named handles into a weight set for coordinate descent.
 struct WeightRef { const char* name; float EvalWeights::* member; };
 
-static const std::array<WeightRef, 12> WEIGHTS = {{
+static const std::array<WeightRef, 17> WEIGHTS = {{
   {"materialWeightMg",      &EvalWeights::materialWeightMg},
   {"materialWeightEg",      &EvalWeights::materialWeightEg},
   {"pieceTableWeightMg",    &EvalWeights::pieceTableWeightMg},
@@ -221,7 +221,12 @@ static const std::array<WeightRef, 12> WEIGHTS = {{
   {"mobRookWeightMg",       &EvalWeights::mobRookWeightMg},
   {"mobQueenWeightMg",      &EvalWeights::mobQueenWeightMg},
   {"threatsWeightMg",       &EvalWeights::threatsWeightMg},
-  {"distanceWeightEg",      &EvalWeights::distanceWeightEg}
+  {"distanceWeightEg",      &EvalWeights::distanceWeightEg},
+  {"bishopPairWeightMg",    &EvalWeights::bishopPairWeightMg},
+  {"bishopPairWeightEg",    &EvalWeights::bishopPairWeightEg},
+  {"rookFileWeightMg",      &EvalWeights::rookFileWeightMg},
+  {"isolatedPawnWeightMg",  &EvalWeights::isolatedPawnWeightMg},
+  {"isolatedPawnWeightEg",  &EvalWeights::isolatedPawnWeightEg}
 }};
 
 // Coordinate descent: probe each weight +-step, keep any move that lowers MSE; when a full


### PR DESCRIPTION
Adds three orthogonal evaluation terms, each fed through the mid/endgame phase
blend and wired into the Texel tuner's cached components (so
`evalFromComponents` still reproduces `evaluate<false>()` bit-for-bit):

- **Bishop pair** — bonus for holding both bishops; larger in the endgame where
  open lines matter more (`mg 40`, `eg 55`).
- **Rook on open / semi-open file** — mg-only; per rook, +2 units on a fully
  open file and +1 on a semi-open file (`rookFileWeightMg 16`).
- **Isolated pawns** — penalty for pawns with no friendly pawn on an adjacent
  file; much milder in the endgame (`mg -16`, `eg -4`).

Weights are Texel-tuned. The cross-dataset signal was the cleanest in the
project's history — all five weights agreed on sign across all three datasets
(big3 / lichess-quiet / quiet-labeled). Adopted the low end of each unanimous
range; `rookFile` was tempered below its tuned ~23 to offset the double-count
with the standing rook-mobility term.

## Arena results

4000 games at 10s + 0.1s vs `master`: **1654W / 1188D / 1158L → +43 Elo**
(95% CI [+34, +52], excludes 0).
