### PR TITLE
PV nodes + PVS (+23 Elo)

### DIFF
--- a/src/node_state.h
+++ b/src/node_state.h
@@ -20,6 +20,11 @@ struct NodeState
   Ply ply;
   int pvIndex;
   int numExtensions;
+
+  // NOTE: PV-ness is deliberately *not* stored here. It is a compile-time
+  // property (`template <bool PvNode>` on alphaBeta and the play* helpers),
+  // since a node is only ever handed its parent's PvNode or a literal false.
+
   Flag hashf = Flag::HASH_ALPHA;
 
   // Node static eval, computed at most once per node (lazy) and reused across

--- a/src/search.h
+++ b/src/search.h
@@ -117,6 +117,20 @@ class SearchData
   //   hashMoveCutoffs  — of those, the hash move alone produced a beta cutoff
   uint64_t ttMoveProvided = 0, hashMoveInList = 0, hashMoveCutoffs = 0;
 
+  // PV-node instrumentation: nodes that had a usable TT cutoff available but
+  // declined it because they were on the principal variation. This is the
+  // entire cost of the PV-node rule — each one is a node that searched its
+  // moves instead of returning a stored score. Compare against ttCutoffs to
+  // see what fraction of the table's work we gave up.
+  uint64_t pvTtCutoffsDeclined = 0;
+
+  // PVS instrumentation, accumulated over the whole search:
+  //   pvsScouts     — non-first moves searched with a null window
+  //   pvsResearches — of those, the scout beat alpha and forced a full re-search
+  // A high researches/scouts ratio means move ordering is feeding PVS bad
+  // first moves — that ratio is the signal to watch.
+  uint64_t pvsScouts = 0, pvsResearches = 0;
+
   private:
 
   Varray<Move, MAX_PLY> pvLine;
@@ -178,7 +192,7 @@ class SearchData
   // walk chains — one unproven move and every later probe describes a position
   // that was never on the PV, which is how this used to print a whole fabricated
   // queen trade off the end of a nine-ply line. A short honest tail beats a long
-  // invented one; see docs/pv-reconstruction.md.
+  // invented one.
   //
   // The appended moves are for display only — see pvSearchedLen for why they
   // are fenced off from isPartOfPv().
@@ -216,6 +230,11 @@ class SearchData
       // -- extensions only ever push that higher, and reductions never apply on
       // the PV, so demanding at least this much admits the real entries and
       // rejects leftovers from shallower iterations.
+      //
+      // Do NOT clamp this to 1 to keep the walk going past rootDepth. Stopping
+      // early in extension-saturated lines is the lesser evil: a floor of 1
+      // re-admits depth-1 entries, which is exactly what let the fabricated
+      // tail through.
       const Depth remaining = rootDepth - Depth(pvLine.size());
       if (remaining < 1)
         break;

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -114,7 +114,27 @@ quiescenceSearch(ChessBoard& pos, Score alpha, Score beta, Ply ply, int pvIndex)
   return alpha;
 }
 
-template <ReductionFunc reductionFunction>
+// Full-window child search with an optional LMR reduction, used on the
+// non-PVS path. ChildPv is a template parameter rather than a bool argument
+// so the child's PV-ness stays compile-time all the way down; the caller
+// resolves the runtime `moveNo == 0` test into one of the two instantiations.
+template <bool ChildPv>
+static Score
+searchChild(
+  ChessBoard& pos, Depth depth, Score alpha, Score beta,
+  Ply ply, int pvNextIndex, int numExtensions, int R
+)
+{
+  Score eval = -alphaBeta<ChildPv>(pos, depth - 1 - R, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
+
+  // if timed-out, eval will be highly negative thus following code won't execute
+  if (R > 0 and eval > alpha)
+    eval = -alphaBeta<ChildPv>(pos, depth - 1, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
+
+  return eval;
+}
+
+template <ReductionFunc reductionFunction, bool PvNode>
 static Score
 playMove(ChessBoard& pos, Move move, size_t moveNo, const NodeState& ns)
 {
@@ -126,37 +146,81 @@ playMove(ChessBoard& pos, Move move, size_t moveNo, const NodeState& ns)
   const int   numExtensions = ns.numExtensions;
 
   Score eval = VALUE_ZERO;
+  pos.makeMove(move);
 
-  if (USE_LMR and lmrOk(move, depth, moveNo))
+  if constexpr (USE_PVS)
   {
-    int R = reductionFunction(depth, moveNo);
-
-    pos.makeMove(move);
-    eval = -alphaBeta(pos, depth - 1 - R, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
-    pos.unmakeMove();
-
-    // if timed-out, eval will be highly negative thus following code won't execute
-    if ((eval > alpha) and (R > 0))
+    // `moveNo == 0` is the first move searched at this node (the hash-move fast
+    // path bumps moveNoBias so its successors arrive with moveNo >= 1) — i.e.
+    // the PV candidate. It gets the full window; every later move is scouted
+    // with a null window [alpha, alpha+1] on the assumption it's worse, and
+    // only re-searched at full depth + full window if the scout beats alpha.
+    if (moveNo == 0)
     {
-      pos.makeMove(move);
-      eval = -alphaBeta(pos, depth - 1, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
-      pos.unmakeMove();
+      eval = -alphaBeta<PvNode>(pos, depth - 1, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
+    }
+    else
+    {
+      const int R = (USE_LMR and lmrOk(move, depth, moveNo)) ? reductionFunction(depth, moveNo) : 0;
+
+      // A scout is a null-window search: its score is a bound, never the real
+      // thing, so it is never a PV node however this node is labelled.
+      info.pvsScouts++;
+      eval = -alphaBeta<false>(pos, depth - 1 - R, -alpha - 1, -alpha, ply + 1, pvNextIndex, numExtensions);
+
+      // Scout beat alpha (and timeout didn't drive it negative): re-search at
+      // full depth + full window for the true score. One step undoes both the
+      // null window and any LMR reduction.
+      //
+      // The `R > 0` term is essential and easy to miss: at a null-window node
+      // (beta == alpha+1) a reduced scout that fails high gives eval == beta, so
+      // `eval < beta` is false and, without `R > 0`, we'd take a beta cutoff on
+      // the word of a shallow LMR-reduced scout — never verifying it at full
+      // depth. That unverified-reduction cutoff is a correctness bug (it lets
+      // reductions hide tactics). When R == 0 the scout is already full depth,
+      // so `eval < beta` alone is the right (pure-PVS) condition.
+      //
+      // The re-search inherits PvNode rather than `false`: a move that beat
+      // alpha at a PV node *is* on the principal variation, so this is where the
+      // "first move is the PV" guess gets corrected. Without it a later move
+      // taking over would leave a truncated pvArray row behind it, which is the
+      // reason proper PV collection wants PVS.
+      if (eval > alpha and (eval < beta or R > 0))
+      {
+        info.pvsResearches++;
+        eval = -alphaBeta<PvNode>(pos, depth - 1, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
+      }
     }
   }
   else
   {
-    // No Reduction
-    pos.makeMove(move);
-    eval = -alphaBeta(pos, depth - 1, -beta, -alpha, ply + 1, pvNextIndex, numExtensions);
-    pos.unmakeMove();
+    const int R = (USE_LMR and lmrOk(move, depth, moveNo)) ? reductionFunction(depth, moveNo) : 0;
+
+    // The first move searched at a PV node is the PV candidate, so it inherits
+    // PV status; its siblings are assumed worse and searched as ordinary nodes.
+    // Unlike the PVS path above — where first-move-vs-scout is already a
+    // structural split — the test is on the runtime `moveNo`, so it has to be
+    // spelled out here to pick the right searchChild instantiation.
+    if constexpr (PvNode)
+    {
+      eval = moveNo == 0
+        ? searchChild<true >(pos, depth, alpha, beta, ply, pvNextIndex, numExtensions, R)
+        : searchChild<false>(pos, depth, alpha, beta, ply, pvNextIndex, numExtensions, R);
+    }
+    else
+    {
+      eval = searchChild<false>(pos, depth, alpha, beta, ply, pvNextIndex, numExtensions, R);
+    }
   }
 
+  pos.unmakeMove();
   return eval;
 }
 
 // Searches the TT-suggested move first at the node's full (boosted) depth so
 // it gets the same effective ply budget as every other move. A beta cutoff
 // here returns without ever running GEN_CHECKS or orderMoves downstream.
+template <bool PvNode>
 static HashMoveOutcome
 playHashMove(ChessBoard& pos, Move hashMove, NodeState& ns, Move& bestMove)
 {
@@ -170,8 +234,10 @@ playHashMove(ChessBoard& pos, Move hashMove, NodeState& ns, Move& bestMove)
 
   const int pvNextIndex = ns.pvNextIndex();
 
+  // The hash move is move 0 at this node, so it carries the node's PV status
+  // down (same rule as playMove's `moveNo == 0`).
   pos.makeMove(hashMove);
-  Score eval = -alphaBeta(pos, ns.depth - 1, -ns.beta, -ns.alpha, ns.ply + 1, pvNextIndex, ns.numExtensions);
+  Score eval = -alphaBeta<PvNode>(pos, ns.depth - 1, -ns.beta, -ns.alpha, ns.ply + 1, pvNextIndex, ns.numExtensions);
   pos.unmakeMove();
 
   if (info.shouldStop())
@@ -201,6 +267,7 @@ playHashMove(ChessBoard& pos, Move hashMove, NodeState& ns, Move& bestMove)
   return out;
 }
 
+template <bool PvNode>
 static Move
 playSubsetMoves(
   ChessBoard& pos, const MoveList& myMoves, MoveArray& movesArray,
@@ -236,7 +303,7 @@ playSubsetMoves(
     if (bestMove == NULL_MOVE)
       bestMove = filter(move);
 
-    Score eval = playMove<reduction>(pos, move, moveNo + moveNoBias, ns);
+    Score eval = playMove<reduction, PvNode>(pos, move, moveNo + moveNoBias, ns);
 
     // No time left! Flag the node as aborted so the caller skips the TT store.
     if (info.shouldStop())
@@ -272,7 +339,8 @@ playSubsetMoves(
   return bestMove;
 }
 
-template <int moveGen, MType orderType, MType... rest>
+// PvNode leads the parameter list because `rest` is a pack and must come last.
+template <bool PvNode, int moveGen, MType orderType, MType... rest>
 static Move
 playAllMoves(
   ChessBoard& pos, MoveList& myMoves,
@@ -292,15 +360,15 @@ playAllMoves(
 
   // Only the residual QUIET stage may futility-prune; earlier stages (captures,
   // promotions, checks, PV, killers) always search their moves.
-  bestMove = playSubsetMoves(pos, myMoves, movesArray, start, end, ns, bestMove,
-                             orderType == MType::QUIET);
+  bestMove = playSubsetMoves<PvNode>(pos, myMoves, movesArray, start, end, ns, bestMove,
+                                     orderType == MType::QUIET);
 
   // Out of time — don't walk the remaining stages just to abort in each of them.
   if (ns.hashf == Flag::HASH_BETA or ns.aborted)
     return bestMove;
 
   if constexpr (sizeof...(rest) > 0)
-    return playAllMoves<moveGen + 1, rest...>(pos, myMoves, movesArray, end, ns, bestMove);
+    return playAllMoves<PvNode, moveGen + 1, rest...>(pos, myMoves, movesArray, end, ns, bestMove);
 
   return bestMove;
 }
@@ -316,6 +384,7 @@ nodeStaticEval(ChessBoard& pos, NodeState& ns)
   return *ns.staticEval;
 }
 
+template <bool PvNode>
 Score
 alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions, bool doNull)
 {
@@ -349,9 +418,20 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
     info.ttProbes++;
     if (ttHit) info.ttHits++;
 
+    // A PV node declines the cutoff and searches on. Returning a bare score
+    // here leaves this node's pvArray row NULL_MOVE, and the whole line below
+    // it is lost to the display — the measured cause of a 7-ply PV printed on
+    // a 37-ply search. The hash move is kept
+    // either way: lookupPosition() surfaces it before the depth test, so
+    // ordering still gets its best-move hint and only the *early return* is
+    // given up. Non-PV nodes are untouched, so the cost is bounded to one node
+    // per ply on the leftmost path.
     if (ttValue != VALUE_UNKNOWN) {
-      info.ttCutoffs++;
-      return ttValue;
+      if constexpr (!PvNode) {
+        info.ttCutoffs++;
+        return ttValue;
+      }
+      else info.pvTtCutoffsDeclined++;
     }
 
     if (hashMove != NULL_MOVE)
@@ -446,9 +526,10 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
       const int pvNextIndex = pvIndex + MAX_PLY - ply;
 
       pos.makeNullMove();
-      Score nullScore = -alphaBeta(pos, nullDepth, -beta, -beta + 1,
-                                   ply + 1, pvNextIndex, numExtensions,
-                                   /*doNull=*/false);
+      // Null-window probe around beta — never a PV node, whatever this node is.
+      Score nullScore = -alphaBeta<false>(pos, nullDepth, -beta, -beta + 1,
+                                          ply + 1, pvNextIndex, numExtensions,
+                                          /*doNull=*/false);
       pos.unmakeNullMove();
 
       if (info.shouldStop())
@@ -496,7 +577,7 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
 
   Move bestMove = NULL_MOVE;
 
-  HashMoveOutcome hashOutcome = playHashMove(pos, hashMove, ns, bestMove);
+  HashMoveOutcome hashOutcome = playHashMove<PvNode>(pos, hashMove, ns, bestMove);
   if (hashOutcome.result.has_value())
     return *hashOutcome.result;
 
@@ -513,7 +594,7 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   // playSubsetMoves — the hash-move fast-path's removeMove() call already
   // bumped that counter, so the LMR_LIMIT gate sees the right moveNo.
   MoveArray movesArray;
-  bestMove = playAllMoves<0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
+  bestMove = playAllMoves<PvNode, 0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
     (pos, myMoves, movesArray, 0, ns, bestMove);
 
   // Skip the store on an aborted node: ns.alpha is a partial bound over however
@@ -527,6 +608,11 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
 
   return ns.alpha;
 }
+
+// alphaBeta is declared in the header but only ever called from this TU, so
+// the two instantiations are named here rather than exposing the definition.
+template Score alphaBeta<true >(ChessBoard&, Depth, Score, Score, Ply, int, int, bool);
+template Score alphaBeta<false>(ChessBoard&, Depth, Score, Score, Ply, int, int, bool);
 
 Score
 rootAlphaBeta(ChessBoard& pos, Score alpha, Score beta, Depth depth)
@@ -543,7 +629,9 @@ rootAlphaBeta(ChessBoard& pos, Score alpha, Score beta, Depth depth)
   {
     Move move = myMoves[moveNo];
 
-    Score eval = playMove<rootReduction>(pos, move, moveNo, ns);
+    // The root is a PV node by definition — every PV node below it is reached
+    // by taking first moves from here down.
+    Score eval = playMove<rootReduction, true>(pos, move, moveNo, ns);
 
     info.insertMoveToList(moveNo);
 
@@ -662,6 +750,17 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
     writer << "Hash move: ttProvided=" << info.ttMoveProvided
            << " inList=" << info.hashMoveInList << " (" << std::fixed << std::setprecision(1) << availRate << "%)"
            << " cutoffs=" << info.hashMoveCutoffs << " (" << cutoffRate << "% of inList)" << endl;
+
+    writer << "PV nodes: ttCutoffsDeclined=" << info.pvTtCutoffsDeclined << endl;
+
+    if constexpr (USE_PVS)
+    {
+      double researchRate = info.pvsScouts
+        ? 100.0 * double(info.pvsResearches) / double(info.pvsScouts) : 0.0;
+      writer << "PVS: scouts=" << info.pvsScouts
+             << " researches=" << info.pvsResearches
+             << " (" << std::fixed << std::setprecision(1) << researchRate << "% of scouts)" << endl;
+    }
 
     writer << "Nodes: " << info.totalSearchedNodes()
            << " | Time: " << std::fixed << std::setprecision(2) << info.timeSpent() << "s"

--- a/src/single_thread.h
+++ b/src/single_thread.h
@@ -37,15 +37,22 @@ search(
 
 /**
  * @brief Returns the evaluation of a board at a given depth
- * 
+ *
+ * @tparam PvNode true when this node lies on the principal variation — the
+ *   root, plus the first move searched at every PV node above it. Never a
+ *   runtime value: a child is passed either its parent's PvNode or a literal
+ *   `false`, so the distinction is resolved at compile time and the two node
+ *   kinds specialize into separate functions (same shape Stockfish uses).
+ *   A PV node declines TT cutoffs so it always writes its pvArray row.
  * @param board ChessBoard to evaluate
  * @param depth depth of the search
- * @param alpha 
- * @param beta 
+ * @param alpha
+ * @param beta
  * @param ply distance from the root
- * @param pvIndex 
- * @return Score 
+ * @param pvIndex
+ * @return Score
  */
+template <bool PvNode>
 Score
 alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pvIndex, int numExtensions, bool doNull = true);
 

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,7 @@ enum SearchFlag: bool
   USE_LMR = true,
   USE_EXTENSIONS = true,
   USE_MOVE_ORDER = true,
+  USE_PVS = true,
   USE_NMP = true,
   USE_RFP = true,
   USE_RAZOR = true,


### PR DESCRIPTION
Makes PV-ness a compile-time property of the search. `alphaBeta` and the
`playHashMove` / `playSubsetMoves` / `playAllMoves` / `playMove` helpers become
`template <bool PvNode>`; a child gets either its parent's `PvNode` or a literal
`false`, never a runtime value, so the two node kinds specialize into separate
functions and `NodeState::pvNode` deliberately doesn't exist.

The one behavioural change is that **a PV node declines TT cutoffs** — it keeps
the hash move for ordering but searches on, so it always writes its `pvArray`
row. That's the fix for PV truncation: master could print a 7-ply line off a
37-ply search, because a TT cutoff on the PV returned a score without ever
filling the row. Built for correctness; the Elo was a side effect.

Also turns on **PVS** behind `USE_PVS` — non-first moves are scouted at
`[-alpha-1, -alpha]` and re-searched at full window (inheriting `PvNode`) on
`eval > alpha and (eval < beta or R > 0)`.

- The `R > 0` term is required, not an optimization: at a null-window node
  `beta == alpha+1`, so a reduced scout failing high gives `eval == beta` and
  `eval < beta` is false — without it you take an unverified beta cutoff on a
  shallow LMR-reduced scout (measured −60 Elo during bring-up).
- `pvsScouts` / `pvsResearches` / `pvTtCutoffsDeclined` counters in `SearchData`.
- `extendPvFromTt`'s `remaining = rootDepth - pvLine.size()` floor is now
  commented as load-bearing — clamping it to 1 re-admits depth-1 TT entries and
  reopens the fabricated-tail bug.

## Arena results

2500 games at 1s + 0.1s vs `master` @ `0301b3d`: **+23.4 Elo**
(95% CI [+12.4, +34.4], excludes 0).

An attribution arena then measured **PV nodes alone** (`USE_PVS = false`) at
**+21.1 Elo** [+12.5, +29.8] over 4000 games, so **PVS's own contribution is
+2.3 ± 14.0 — statistically zero**. The Elo is the TT-decline rule. PVS is kept
for the forward option on LMR aggression (a verified full-depth re-search is
what lets you reduce harder), not for measured Elo. This supersedes the earlier
−15 Elo standalone PVS result, which stands as true of PVS *without* PV nodes.

Note for reviewers: `if constexpr` discards the untaken `USE_PVS` arm without
type-checking it, so any later change to `playMove` needs one build with the
flag flipped.
