### PR TITLE
uci: serialise stdout through a uciSend mutex

### DIFF
--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -2,7 +2,9 @@
 #include "single_thread.h"
 #include "move_utils.h"
 #include "node_state.h"
+#include "uci.h"
 #include <iostream>
+#include <sstream>
 
 uint64_t
 bulkCount(ChessBoard& pos, Depth depth)
@@ -699,8 +701,13 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
 
       if (emitUciInfo)
       {
+        // Built into a string and handed to uciSend() rather than streamed
+        // straight to std::cout: this runs on the search worker while the UCI
+        // loop may be answering `isready` on the main thread, and the two share
+        // one unsynchronised streambuf (see uciSend in uci.h).
         long long timeMs = static_cast<long long>(info.timeSpent() * 1000.0);
-        std::cout << "info depth " << int(depth)
+        std::ostringstream line;
+        line      << "info depth " << int(depth)
                   << " score cp " << int(eval)
                   << " nodes " << info.totalSearchedNodes()
                   << " nps " << info.nps()
@@ -715,9 +722,9 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
         for (const Move m : info.getPvLine())
         {
           if (m & quiescenceMove()) break;
-          std::cout << " " << moveToUci(m);
+          line << " " << moveToUci(m);
         }
-        std::cout << std::endl;
+        uciSend(line.str());
       }
 
       info.resetNodeCount();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <atomic>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -22,6 +23,10 @@ using std::stringstream;
 
 namespace
 {
+
+// Serialises every write to stdout. See uciSend() in uci.h for why std::cout
+// has no lock of its own here.
+std::mutex g_outMutex;
 
 // Persistent board across commands within a session.
 ChessBoard g_board(START_FEN);
@@ -49,9 +54,9 @@ stopAndJoin()
 void
 sendId()
 {
-  cout << "id name Elsa" << endl;
-  cout << "id author Andr0human" << endl;
-  cout << "uciok" << endl;
+  uciSend("id name Elsa");
+  uciSend("id author Andr0human");
+  uciSend("uciok");
 }
 
 void
@@ -212,7 +217,7 @@ handleGo(stringstream& ss)
   g_worker = std::thread([board = g_board, maxDepth, moveTimeSec]() {
     std::ostringstream sink;
     search(board, maxDepth, moveTimeSec, sink, false, true);
-    cout << "bestmove " << moveToUci(info.lastIterationResult().first) << endl;
+    uciSend("bestmove " + moveToUci(info.lastIterationResult().first));
   });
 }
 
@@ -228,6 +233,13 @@ handleUciNewGame()
 }
 
 } // namespace
+
+void
+uciSend(const string& line)
+{
+  std::lock_guard<std::mutex> lock(g_outMutex);
+  cout << line << endl;
+}
 
 void
 uciLoop()
@@ -246,7 +258,7 @@ uciLoop()
     }
     else if (cmd == "isready")
     {
-      cout << "readyok" << endl;
+      uciSend("readyok");
     }
     else if (cmd == "ucinewgame")
     {

--- a/src/uci.h
+++ b/src/uci.h
@@ -3,6 +3,19 @@
 #define UCI_H
 
 #include "base_utils.h"
+#include <string>
+
+// Write one line to stdout under the UCI output lock, then flush.
+//
+// Every UCI line MUST go through here. Two threads emit protocol output — the
+// UCI loop (uciok / readyok / id) and the search worker (info / bestmove) — and
+// FAST_IO() calls sync_with_stdio(0), which detaches std::cout from C stdio and
+// so from the FILE lock that would otherwise have serialised them. Two threads
+// then share one unsynchronised streambuf: concurrent sputn/overflow corrupts
+// pptr, which shreds lines outright ("info depth readyok", "-72readyok readyok0")
+// and can flush one buffer twice. A mangled `bestmove` or `readyok` is invisible
+// to the engine but reads to the GUI as an unresponsive engine — a forfeit.
+void uciSend(const std::string& line);
 
 // Run the UCI command loop on stdin/stdout. Returns when "quit" is received
 // or stdin is closed.


### PR DESCRIPTION
`FAST_IO()` calls `sync_with_stdio(0)`, which detaches `std::cout` from C stdio
and so from the `FILE` lock that had been silently serialising it. Since PR #56
made search asynchronous, two threads share one unsynchronised streambuf — the
UCI loop (`uciok`/`readyok`/`id`) and the search worker (`info`/`bestmove`).
The race is on `pptr`, not on line boundaries, so lines get shredded, duplicated,
or dropped entirely. A dropped `readyok` is what a GUI reports as an
unresponsive engine — one forfeit in a recent 2000-game gauntlet.

New `uciSend(const std::string&)` takes a mutex and writes one whole line; all
protocol output goes through it, including the `info` printer in `search()`.

Verified: stress-driving `go infinite` against an `isready` spam loop went from
361 lost `readyok` in 256,000 to 347,200/347,200 with 0 malformed. Node counts
are bit-identical at fixed depth, and an arena run came back Elo-neutral as
expected — this ships on correctness, not strength.