### PR TITLE
History heuristic + root-ordering replacement (+24 Elo)

### DIFF
--- a/src/node_state.h
+++ b/src/node_state.h
@@ -45,6 +45,14 @@ struct NodeState
   bool aborted = false;
 
   constexpr int pvNextIndex() const noexcept { return pvIndex + MAX_PLY - ply; }
+
+  // The quiet-futility skip test, in one place because two sites must agree on
+  // it: playSubsetMoves breaks out of the QUIET stage on it, and playAllMoves
+  // reads it to decide whether ordering that stage is worth paying for. Let the
+  // two expressions drift apart and the failure isn't a wasted sort — it's an
+  // unsorted band that does get searched, i.e. a silent move-ordering change.
+  constexpr bool skipsQuiets(Move bestMove) const noexcept
+  { return quietFutile and bestMove != NULL_MOVE; }
 };
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -27,8 +27,45 @@ prioritizeMoves(MoveArray& movesArray, size_t start)
   return start;
 }
 
+// Order the residual QUIET band by history score, descending.
+//
+// Scored once into a parallel array rather than inside a comparator (the
+// orderCaptures pattern) — the band averages ~26 moves, so a comparator would
+// redo the same three-level lookup ~2n*log(n) times. The insertion sort is
+// stable under `<`, which matters: v1 never applies malus, so every move that
+// has not yet cut off sits at 0, and those keep their emission order instead of
+// being shuffled arbitrarily among themselves.
+static void
+sortByHistory(Color color, MoveArray& movesArray, size_t start)
+{
+  const size_t n = movesArray.size();
+  if (n - start < 2)
+    return;
+
+  array<int32_t, MAX_MOVES> scores;
+  for (size_t i = start; i < n; i++)
+    scores[i] = historyScore(color, movesArray[i]);
+
+  for (size_t i = start + 1; i < n; i++)
+  {
+    const Move    move  = movesArray[i];
+    const int32_t score = scores[i];
+    size_t j = i;
+
+    while (j > start and scores[j - 1] < score)
+    {
+      movesArray[j] = movesArray[j - 1];
+      scores[j]     = scores[j - 1];
+      --j;
+    }
+
+    movesArray[j] = move;
+    scores[j]     = score;
+  }
+}
+
 size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, size_t start)
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, size_t start, bool useHistory)
 {
   const auto seeComparator = [&pos] (Move move1, Move move2)
   { return seeScore(pos, move1) > seeScore(pos, move2); };
@@ -64,6 +101,20 @@ orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType mTypes, Ply ply, 
       if (killerMoves[ply].search(movesArray[i]))
         std::swap(movesArray[i], movesArray[start++]);
     }
+  }
+
+  // History ordering of the residual QUIET band. Placed after the killer
+  // partition so killers keep their slot ahead of history, and only on the
+  // QUIET stage — the earlier stages are already ordered by SEE and would be
+  // scrambled by a key that only means anything for quiets.
+  //
+  // `useHistory` is the call site's veto: it knows (and orderMoves doesn't) when
+  // the stage is about to break on move 0 under quiet futility, where the sort
+  // is pure waste — measured at ~29% of shallow quiet stages.
+  if constexpr (USE_HISTORY)
+  {
+    if (hasFlag(mTypes, MType::QUIET) and useHistory)
+      sortByHistory(pos.color, movesArray, start);
   }
 
   return (hasFlag(mTypes, MType::QUIET)) ? movesArray.size() : start;

--- a/src/search.h
+++ b/src/search.h
@@ -495,8 +495,12 @@ class SearchData
   }
 };
 
+// `useHistory` gates only the residual-QUIET history sort: pass false when the
+// caller already knows the stage will break on its first move (quiet futility),
+// so the sort isn't paid for a band nothing will read.
 size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply, size_t start = 0);
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply,
+           size_t start = 0, bool useHistory = true);
 
 /**
  * @brief SEE-orders a pure capture list for quiescence search.

--- a/src/search.h
+++ b/src/search.h
@@ -82,6 +82,18 @@ class TestPosition
 // rebuilt by copy-assignment (`info = SearchData(...)`) on every search.
 extern std::atomic<bool> searchStop;
 
+// Declared ahead of SearchData because its constructor calls this to seed the
+// root move order. A member body defined inline inside the class can't see a
+// namespace-scope name declared later in the file, so this block must stay
+// above the class.
+//
+// `useHistory` gates only the residual-QUIET history sort: pass false when the
+// caller already knows the stage will break on its first move (quiet futility),
+// so the sort isn't paid for a band nothing will read.
+size_t
+orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply,
+           size_t start = 0, bool useHistory = true);
+
 class SearchData
 {
   // Set the starting point for clock
@@ -267,9 +279,32 @@ class SearchData
   : startTime(perf::now()), side(pos.color), nodes(0), qNodes(0),
     allotedTime(std::chrono::duration_cast<nanoseconds>(std::chrono::duration<double>(_allotedTime)))
   {
-    const MoveList myMoves = generateMoves(pos);
+    // generateChecksData: MType::CHECK ordering below is silently a no-op
+    // without it — is_type<MType::CHECK> reads data only GEN_CHECKS fills.
+    const MoveList myMoves = generateMoves(pos, true);
     MoveArray movesArray;
     myMoves.getMoves(pos, movesArray);
+
+    // Iteration 1 has no search results to order by, so seed the root list with
+    // the same static ordering the rest of the tree uses. Written as successive
+    // per-stage calls rather than one combined mask, mirroring playAllMoves: a
+    // combined mask would skip bad-capture demotion (gated on
+    // `mTypes == MType::CAPTURES` exactly) and SEE-sort captures/promotions/
+    // checks as one band instead of three.
+    //
+    // Two stages are deliberately absent:
+    //   PV     — is_type<MType::PV> reads the *global* `info`, which is still
+    //            the previous search's object until our caller assigns over it,
+    //            and resetPvLine() doesn't clear it. There is no PV for this
+    //            position yet anyway.
+    //   KILLER — clearKillers() runs immediately before us; the table is empty.
+    // History is likewise cleared, hence useHistory=false throughout: the sort
+    // would be a provable no-op over all-zero scores.
+    size_t start = 0;
+    start = orderMoves(pos, movesArray, MType::CAPTURES,  0, start, false);
+    start = orderMoves(pos, movesArray, MType::PROMOTION, 0, start, false);
+            orderMoves(pos, movesArray, MType::CHECK,     0, start, false);
+
     Move zeroMove = movesArray[0];
     moveEvals.add(make_pair(zeroMove, VALUE_ZERO));
 
@@ -436,26 +471,49 @@ class SearchData
            << " | " << "PV" << "\n";
   }
 
-  // Reorder root moves for the next iteration: keep the PV move first, then
-  // order the rest by descending subtree size (2*nodes + qNodes) so the
-  // hardest-to-resolve moves are searched earliest.
+  // Reorder root moves for the next iteration: move `bestMove` to the front and
+  // leave every other move where it is.
+  //
+  // The tail used to be re-sorted by descending subtree size (2*nodes + qNodes),
+  // on the theory that the hardest-to-resolve moves deserve the earliest slots.
+  // That fights move ordering rather than helping it: node count measures how
+  // expensive a move was to refute, not how good it is, so a cheap-subtree move
+  // — a move refuted quickly *because* it is bad, but also a strong move whose
+  // subtree collapsed on a cutoff — gets buried at the back. Root LMR is keyed
+  // on list index (rootReduction, up to R=3 at depth >= 6), so burial costs
+  // search depth, not just order; that is the mechanism behind the measured
+  // 4-ply tactic delay. The node counts are still recorded — insertMoveToList /
+  // totalNodes / print all read them — they just no longer drive ordering.
   void
-  sortMovesOnNodes(Move bestMove)
+  promoteBestMove(Move bestMove)
   {
+    // Aspiration fail-low: rootAlphaBeta returns without ever writing
+    // pvArray[0], since by definition no move beat alpha. Fall back to the last
+    // completed iteration's best move — moveEvals is seeded in the constructor
+    // and only appended on completed iterations, so back() is always a legal
+    // move of this position. (With the node sort gone this is belt-and-braces:
+    // pinning nothing now leaves the list untouched, and the previous iteration
+    // already put its best move in slot 0. It matters the moment anything
+    // reorders the tail again.)
+    if (bestMove == NULL_MOVE)
+    {
+      if (moveEvals.size() == 0)
+        return;
+      bestMove = moveEvals.back().first;
+    }
+
     for (size_t i = 0; i < moveNodes.size(); i++)
     {
       if (filter(bestMove) == filter(moveNodes[i].first))
       {
-        std::swap(moveNodes[i], moveNodes[0]);
+        // Rotate, not swap. With the sort gone the tail carries meaningful
+        // order, and std::swap would fling whatever held slot 0 out to
+        // position i. rotate(begin, begin+i, begin+i+1) lifts element i to the
+        // front, shifts 0..i-1 right by one, and leaves everything past i alone.
+        std::rotate(moveNodes.begin(), moveNodes.begin() + i, moveNodes.begin() + i + 1);
         break;
       }
     }
-
-    std::sort(moveNodes.begin() + 1, moveNodes.end(), [](const auto &a, const auto &b) {
-      Nodes n1 = 2 * a.second.first + a.second.second;
-      Nodes n2 = 2 * b.second.first + b.second.second;
-      return n1 > n2;
-    });
   }
 
   void
@@ -494,13 +552,6 @@ class SearchData
     return movesArray;
   }
 };
-
-// `useHistory` gates only the residual-QUIET history sort: pass false when the
-// caller already knows the stage will break on its first move (quiet futility),
-// so the sort isn't paid for a band nothing will read.
-size_t
-orderMoves(const ChessBoard& pos, MoveArray& movesArray, MType moveTypes, Ply ply,
-           size_t start = 0, bool useHistory = true);
 
 /**
  * @brief SEE-orders a pure capture list for quiescence search.

--- a/src/search_utils.cpp
+++ b/src/search_utils.cpp
@@ -4,6 +4,7 @@
 
 Move pvArray[MAX_PV_ARRAY_SIZE];
 array<Varray<Move, 2>, MAX_PLY> killerMoves;
+array<array<array<int32_t, SQUARE_NB>, SQUARE_NB>, COLOR_NB> historyTable;
 
 void
 movcpy(Move* pTarget, const Move* pSource, int n)
@@ -21,6 +22,27 @@ clearKillers()
 {
   for (auto& slot : killerMoves)
     slot.clearKillerMoves();
+}
+
+void
+clearHistory()
+{
+  for (auto& byColor : historyTable)
+    for (auto& byFrom : byColor)
+      byFrom.fill(0);
+}
+
+void
+updateHistory(Color c, Move move, Depth depth)
+{
+  // depth is >= 1 here: alphaBeta hands depth <= 0 to quiescenceSearch before
+  // any move is staged, so the bonus is always positive.
+  const int bonus = int(depth) * int(depth);
+  int32_t& h = historyTable[c][size_t(from_sq(move))][size_t(to_sq(move))];
+
+  // h is bounded by MAX_HISTORY and bonus by (MAX_DEPTH + EXTENSION_LIMIT)^2,
+  // so the product stays far inside int32.
+  h += int32_t(bonus - int(h) * bonus / int(MAX_HISTORY));
 }
 
 Score

--- a/src/search_utils.h
+++ b/src/search_utils.h
@@ -7,6 +7,17 @@
 extern Move pvArray[MAX_PV_ARRAY_SIZE];
 extern array<Varray<Move, 2>, MAX_PLY> killerMoves;
 
+// Butterfly history table, [color][from][to] — 2 * 64 * 64 * 4 B = 32 KB.
+// Records how often a *quiet* move produced a beta cutoff, weighted by the
+// depth it did it at, and is used to order the residual QUIET stage that
+// otherwise runs in raw movegen emission order.
+//
+// Color indexing gotcha: Color is BLACK = 0, WHITE = 1 — inverted from the
+// usual convention. Indexing by pos.color is correct (it's just an index), but
+// any hand-written initializer or debug dump must not assume WHITE = 0. This
+// has bitten silently before; there is no compile error for getting it wrong.
+extern array<array<array<int32_t, SQUARE_NB>, SQUARE_NB>, COLOR_NB> historyTable;
+
 
 void
 movcpy(Move* pTarget, const Move* pSource, int n);
@@ -16,6 +27,29 @@ resetPvLine();
 
 void
 clearKillers();
+
+// Zero the history table. Called per search alongside clearKillers(), so v1
+// carries no state between moves of a game — keeping (or halving) it across
+// moves is a separate knob, deliberately not bundled into the first A/B.
+void
+clearHistory();
+
+// Reward a quiet move that produced a beta cutoff at `depth`.
+//
+// Gravity form: the increment shrinks as the entry grows, which bounds the
+// table in (-MAX_HISTORY, MAX_HISTORY) by construction and decays stale entries
+// on its own. The classic alternative — accumulate depth*depth and halve the
+// whole table on overflow — would need a periodic 32 KB sweep, and there is no
+// natural place in this codebase's control flow to hang one.
+void
+updateHistory(Color c, Move move, Depth depth);
+
+// Ordering key for the residual QUIET stage. Never updated for captures, so a
+// SEE<0 capture demoted into that band by orderMoves() scores 0 and sinks below
+// every quiet that has ever cut off — which is the intended treatment.
+inline int32_t
+historyScore(Color c, Move move)
+{ return historyTable[c][size_t(from_sq(move))][size_t(to_sq(move))]; }
 
 Score
 checkmateScore(Ply ply);

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -768,8 +768,9 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
     // If found a checkmate
     if (withinValWindow and (__abs(eval) >= VALUE_INF - 500)) break;
 
-    // Sort Moves according to time it took to explore the move.
-    info.sortMovesOnNodes(pvArray[0]);
+    // Put this iteration's best move first for the next one. pvArray[0] is
+    // NULL_MOVE on an aspiration fail-low; promoteBestMove handles that itself.
+    info.promoteBestMove(pvArray[0]);
   }
 
   info.searchCompleted();

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -312,7 +312,7 @@ playSubsetMoves(
     // / checks / PV / killers ran in earlier stages), so every move here is
     // already quiet & non-check — no per-move type test needed. Unverified bet
     // (cf. razoring's qsearch check); the depth-scaled margin is the safety.
-    if (futilityStage and ns.quietFutile and bestMove != NULL_MOVE)
+    if (futilityStage and ns.skipsQuiets(bestMove))
       break;
 
     // HASH_ALPHA fallback: remember the first searched move at this node so
@@ -381,10 +381,12 @@ playAllMoves(
   // movesArray.size() anyway. Routing the stage through orderMoves gives the
   // history sort somewhere to live.
   //
-  // Don't pay for that sort when playSubsetMoves is about to break on move 0:
-  // this is the same predicate it tests there, and it's true on a large minority
-  // of shallow quiet stages.
-  const bool useHistory = !(ns.quietFutile and bestMove != NULL_MOVE);
+  // Don't pay for that sort when playSubsetMoves is about to break on move 0 --
+  // literally its own break condition (ns.skipsQuiets), evaluated one call
+  // earlier on the same unchanged state, and true on a large minority of
+  // shallow quiet stages. The stage test mirrors the `futilityStage` argument
+  // below, so the two predicates stay identical by construction.
+  const bool useHistory = !(orderType == MType::QUIET and ns.skipsQuiets(bestMove));
   size_t end = orderMoves(pos, movesArray, orderType, ns.ply, start, useHistory);
 
   // Only the residual QUIET stage may futility-prune; earlier stages (captures,

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -338,7 +338,11 @@ playSubsetMoves(
       bestMove = filter(move);
 
       if (is_type<MType::QUIET>(move))
+      {
         killerMoves[ns.ply].addKillerMove(move);
+        if constexpr (USE_HISTORY)
+          updateHistory(pos.color, move, ns.depth);
+      }
       break;
     }
 
@@ -371,9 +375,17 @@ playAllMoves(
   if constexpr (moveGen == 1)
     myMoves.getMoves<MType::QUIET, MType::CHECK>(pos, movesArray);
 
-  size_t end = orderType == MType::QUIET
-    ? movesArray.size()
-    : orderMoves(pos, movesArray, orderType, ns.ply, start);
+  // The residual QUIET stage used to short-circuit to movesArray.size() here.
+  // That was only ever an optimization: with mTypes == MType::QUIET every
+  // prioritize/sort/killer branch inside orderMoves is gated off and it returns
+  // movesArray.size() anyway. Routing the stage through orderMoves gives the
+  // history sort somewhere to live.
+  //
+  // Don't pay for that sort when playSubsetMoves is about to break on move 0:
+  // this is the same predicate it tests there, and it's true on a large minority
+  // of shallow quiet stages.
+  const bool useHistory = !(ns.quietFutile and bestMove != NULL_MOVE);
+  size_t end = orderMoves(pos, movesArray, orderType, ns.ply, start, useHistory);
 
   // Only the residual QUIET stage may futility-prune; earlier stages (captures,
   // promotions, checks, PV, killers) always search their moves.
@@ -612,6 +624,7 @@ alphaBeta(ChessBoard& pos, Depth depth, Score alpha, Score beta, Ply ply, int pv
   // LMR bias is now derived from myMoves.removedMoves() inside
   // playSubsetMoves — the hash-move fast-path's removeMove() call already
   // bumped that counter, so the LMR_LIMIT gate sees the right moveNo.
+
   MoveArray movesArray;
   bestMove = playAllMoves<PvNode, 0, MType::CAPTURES, MType::PROMOTION, MType::CHECK, MType::PV, MType::KILLER, MType::QUIET>
     (pos, myMoves, movesArray, 0, ns, bestMove);
@@ -673,6 +686,7 @@ search(ChessBoard board, Depth mDepth, double search_time, std::ostream& writer,
 {
   resetPvLine();
   clearKillers();
+  clearHistory();
 
   if (!generateMoves(board).anyMove())
   {

--- a/src/types.h
+++ b/src/types.h
@@ -1,4 +1,4 @@
-
+﻿
 #ifndef TYPES_H
 #define TYPES_H
 
@@ -35,6 +35,7 @@ enum SearchFlag: bool
   USE_RFP = true,
   USE_RAZOR = true,
   USE_FUTILITY = true,
+  USE_HISTORY = true,
 };
 
 enum Color: uint8_t
@@ -69,6 +70,11 @@ enum Search
   MAX_PLY = 50,
   MAX_DEPTH = 40,
   LMR_LIMIT = 4,
+  // Saturation point of the butterfly history table. The gravity update
+  // (h += bonus - h*bonus/MAX_HISTORY) keeps every entry inside
+  // (-MAX_HISTORY, MAX_HISTORY) by construction, so there is no overflow sweep
+  // to schedule. Keep it inside int16 range if the table is ever narrowed.
+  MAX_HISTORY = 16384,
   EXTENSION_LIMIT = 8,
   NMP_MIN_DEPTH = 3,
   VAL_WINDOW = 16,


### PR DESCRIPTION
Orders the residual QUIET stage, which until now was searched in raw movegen
emission order. A butterfly `[color][from][to]` table behind `USE_HISTORY`
scores quiets by depth² on cutoff and sorts the band. This matters most for LMR,
which is keyed on `moveNo` — within the quiet band the reduction ladder wasn't
measuring move quality at all.

Also **replaces `sortMovesOnNodes` with `promoteBestMove`** at the root. Root
ordering was PV-move-first then descending subtree node count, which fights
history directly: shrinking subtree node counts is history's whole job, so a
move whose refutations are well-known history moves reads as "cheap =
unimportant" and gets buried. Node counts are still recorded, they just no
longer drive ordering.

## Arena results

Two independent runs at 1s + 0.1s vs `master`:

| run | games | W–D–L | score | Elo | 95% CI |
|---|---|---|---|---|---|
| 1 | 2300 | 804–889–607 | .5428 | +29.8 | [+18.7, +41.0] |
| 2 | 2700 | 914–1026–760 | .5285 | +19.8 | [+9.5, +30.2] |
| **pooled** | **5000** | **1718–1915–1367** | **.5351** | **+24.4** | **[+16.9, +32.0]** |
