### PR TITLE
search: fix is_type<QUIET> masking the color bit (+42 Elo)

### DIFF
--- a/src/search_utils.h
+++ b/src/search_utils.h
@@ -70,8 +70,14 @@ is_type(Move m)
   if constexpr (mt == MType::CHECK)
     return (m >> 23) & 1;
 
+  // Bits 20 (CAPTURES) and 21 (PROMOTION) only -- a quiet move is one that is
+  // neither. The mask must NOT reach bit 22: that is the color bit, set on
+  // every move of the side whose Color is 1, and Color is BLACK = 0,
+  // WHITE = 1. Masking it in made this return false for all of White's moves,
+  // which silently emptied historyTable[WHITE] and White's killer slots (the
+  // sole call site gates both).
   if constexpr (mt == MType::QUIET)
-    return ((m >> 20) & 7) == 0;
+    return ((m >> 20) & 3) == 0;
 
   if constexpr (mt == MType::CAPTURES)
     return (m >> 20) & 1;


### PR DESCRIPTION
## The bug

`is_type<MType::QUIET>` tested `((m >> 20) & 7) == 0`.

The mask spans bits 20–22, but only bits 20 (CAPTURES) and 21 (PROMOTION) are
move-type flags — **bit 22 is the color bit**. Since `Color` is `BLACK = 0,
WHITE = 1`, bit 22 is set on every White move, so the predicate returned `false`
for all of them. A White quiet move was never recognized as quiet.

```diff
-    return ((m >> 20) & 7) == 0;
+    return ((m >> 20) & 3) == 0;
```

## Impact

The sole call site is the beta-cutoff block in `alphaBeta`, and it gates **both**
killer storage and the history update:

```cpp
if (is_type<MType::QUIET>(move))
{
  killerMoves[ns.ply].addKillerMove(move);
  if constexpr (USE_HISTORY)
    updateHistory(pos.color, move, ns.depth);
}
```

So on every White-to-move node the engine stored no killer and no history entry.
This is not lopsided by which side the engine plays — it fires at half the
interior nodes of every search regardless of root color.

Nonzero `historyTable` entries after a depth-11 search:

| | BLACK | WHITE |
|---|---|---|
| before | 122 | **0** |
| after | 130 | 129 |

## Testing

**Arena: +42.1 Elo [+30.0, +54.2]**, 2000 games @ 1s+0.1s, 746W / 749D / 505L.
