### PR TITLE
Quiet promotions in qsearch (+20 Elo)

### DIFF
--- a/src/movelist.cpp
+++ b/src/movelist.cpp
@@ -294,6 +294,18 @@ MoveList::getMoves(const ChessBoard& pos, MoveArray& movesArray) const noexcept
 {
   const Move colorBit = Move(color) << 22;
 
+  // MType::PROMOTION as an mt1 *selector* means "the quiet pawn moves that land
+  // on the last rank" -- the subset getMoves<QUIET> already emits with bit 21
+  // set, and the one qsearch was missing (promotion-captures carry bit 20 and
+  // so arrive with CAPTURES). The fills below still run as MType::QUIET, so the
+  // emitted encoding is bit-identical to the normal quiet path: fillPawns ORs
+  // in the promotion bit itself for Rank18 destinations. Only the destination
+  // mask and the skipped piece/king loops differ.
+  constexpr bool quietPawns = hasFlag(mt1, MType::QUIET) or hasFlag(mt1, MType::PROMOTION);
+  constexpr bool pieceMoves = hasFlag(mt1, MType::QUIET) or hasFlag(mt1, MType::CAPTURES);
+  constexpr Bitboard quietMask =
+    hasFlag(mt1, MType::QUIET) ? Bitboard(AllSquares) : Bitboard(Rank18);
+
   // fix pawns
   Bitboard emyPieces = pos.getPiece(~color, ALL);
   Bitboard kingMask  = pos.getPiece(color, KING) & initSquares;
@@ -307,10 +319,12 @@ MoveList::getMoves(const ChessBoard& pos, MoveArray& movesArray) const noexcept
       fillShiftPawns<MType::CAPTURES, mt2>(pos, movesArray, pawnDestSquares[0], 7 - 16 * color);
       fillShiftPawns<MType::CAPTURES, mt2>(pos, movesArray, pawnDestSquares[1], 9 - 16 * color);
     }
-    if (hasFlag(mt1, MType::QUIET))
+    if constexpr (quietPawns)
     {
-      fillShiftPawns<MType::QUIET, mt2>(pos, movesArray, pawnDestSquares[2], 16 - 32 * color);
-      fillShiftPawns<MType::QUIET, mt2>(pos, movesArray, pawnDestSquares[3],  8 - 16 * color);
+      // A double push can never land on the last rank, so PROMOTION skips it.
+      if constexpr (hasFlag(mt1, MType::QUIET))
+        fillShiftPawns<MType::QUIET, mt2>(pos, movesArray, pawnDestSquares[2], 16 - 32 * color);
+      fillShiftPawns<MType::QUIET, mt2>(pos, movesArray, pawnDestSquares[3] & quietMask, 8 - 16 * color);
     }
 
     while (pawnMask > 0)
@@ -326,15 +340,15 @@ MoveList::getMoves(const ChessBoard& pos, MoveArray& movesArray) const noexcept
       if (hasFlag(mt1, MType::CAPTURES))
         fillPawns<MType::CAPTURES, mt2>(pos, movesArray,  captSquares, baseMove);
 
-      if (hasFlag(mt1, MType::QUIET))
-        fillPawns<MType::QUIET, mt2>(pos, movesArray, quietSquares, baseMove);
+      if constexpr (quietPawns)
+        fillPawns<MType::QUIET, mt2>(pos, movesArray, quietSquares & quietMask, baseMove);
     }
   }
 
   if (hasFlag(mt1, MType::CAPTURES))
     fillEnpassantPawns<mt1, mt2>(pos, movesArray);
 
-  while (pieceMask > 0)
+  while (pieceMoves and pieceMask > 0)
   {
     Square     ip = nextSquare(pieceMask);
     PieceType ipt = type_of(pos.pieceOnSquare(ip));
@@ -354,7 +368,7 @@ MoveList::getMoves(const ChessBoard& pos, MoveArray& movesArray) const noexcept
       fillMoves<MType::QUIET, mt2>(pos, movesArray, quietSquares, baseMove);
   }
 
-  if (kingMask)
+  if (pieceMoves and kingMask)
   {
     Square     ip = squareNo(kingMask);
     Move baseMove = colorBit | (Move(KING) << 12) | ip;
@@ -397,6 +411,45 @@ MoveList::exists<MType::CAPTURES>(const ChessBoard& pos) const noexcept
 {
   Bitboard emyPieces = pos.getPiece(~color, ALL);
   return (myAttackedSquares & emyPieces) or enpassantPawns;
+}
+
+template <>
+bool
+MoveList::exists<MType::PROMOTION>(const ChessBoard& pos) const noexcept
+{
+  // Quiet promotions only -- promotion-captures already answer to
+  // exists<CAPTURES>, since they carry the capture bit. Mirrors the PROMOTION
+  // branch of getMoves: pawn sources only, single pushes only, Rank18 only.
+
+  // Cheapest possible reject first: no pawn one rank from promoting. Color is
+  // BLACK = 0, WHITE = 1, and BLACK pushes toward Rank1 -- hence Rank2 in slot
+  // 0 and Rank7 in slot 1, not the other way round.
+  constexpr Bitboard prePromoRank[COLOR_NB] = { Rank2, Rank7 };
+  if ((myPawns & prePromoRank[color]) == 0)
+    return false;
+
+  // Load-bearing, not an optimization: in double check pieceMovement() never
+  // runs, so pawnDestSquares[] is left uninitialized (the constructor zeroes
+  // checkers/initSquares/enpassantPawns but not the dest arrays). getMoves
+  // guards its own pawn section the same way. Reading slot 3 below is only
+  // safe once this has returned.
+  if (checkers >= 2)
+    return false;
+
+  if (pawnDestSquares[3] & Rank18)
+    return true;
+
+  Bitboard emyPieces = pos.getPiece(~color, ALL);
+  Bitboard pawnMask  = myPawns & initSquares;
+
+  while (pawnMask > 0)
+  {
+    Square ip = nextSquare(pawnMask);
+    if (destSquares[ip] & Rank18 & ~emyPieces)
+      return true;
+  }
+
+  return false;
 }
 
 template <>
@@ -592,3 +645,5 @@ template void MoveList::getMoves<MType(2), MType(0)>(const ChessBoard&, MoveArra
 template void MoveList::getMoves<MType(2), MType(4)>(const ChessBoard&, MoveArray&) const noexcept;
 template void MoveList::getMoves<MType(3), MType(0)>(const ChessBoard&, MoveArray&) const noexcept;
 template void MoveList::getMoves<MType(3), MType(4)>(const ChessBoard&, MoveArray&) const noexcept;
+// MType(8) == PROMOTION: quiet promotions only, for the quiescence search.
+template void MoveList::getMoves<MType(8), MType(0)>(const ChessBoard&, MoveArray&) const noexcept;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -190,11 +190,23 @@ seeScore(const ChessBoard& pos, Move move)
   const PieceType fpt = PieceType((move >> 15) & 7);
 
   const Color side = ~pos.color;
-  const Score initialValue =
+  Score initialValue =
     (is_type<MType::CAPTURES>(move) and fpt == NONE) ? pieceValues[PAWN] : pieceValues[fpt];
 
   Bitboard removedPieces = 1ULL << ip;
   PieceType pieceOnSquare = type_of(pos.pieceOnSquare(ip));
+
+  // A promotion swaps the pawn for the promoted piece before the opponent can
+  // recapture. Credit that material gain, and hand see() the piece that
+  // actually lands on `fp` rather than the pawn that left `ip` -- otherwise
+  // every flavor of a promotion scores identically (0 undefended, -100
+  // defended), so the PROMOTION ordering stage cannot tell a queen from a
+  // bishop and capture-promotions sort by victim alone.
+  if (is_type<MType::PROMOTION>(move))
+  {
+    pieceOnSquare = PieceType(((move >> 18) & 3) + 2);
+    initialValue += pieceValues[pieceOnSquare] - pieceValues[PAWN];
+  }
 
   Score seeScore = initialValue - see(pos, fp, side, pieceOnSquare, removedPieces);
   return seeScore;

--- a/src/single_thread.cpp
+++ b/src/single_thread.cpp
@@ -55,10 +55,11 @@ quiescenceSearch(ChessBoard& pos, Score alpha, Score beta, Ply ply, int pvIndex)
   // away. Without it an already-drawn leaf came back as a static eval (+3.75 on a
   // dead-drawn KRN-vs-KR at halfmove 100) and the draw only surfaced an iteration
   // later, once the same position sat at an interior node. One test here covers
-  // the whole capture tree below: qsearch only searches captures, which are
-  // irreversible and reset the halfmove clock, so neither draw can arise deeper.
-  // It sits *after* the mate/stalemate test above because checkmate outranks the
-  // 50-move rule — movegen has already run by here, so that costs nothing.
+  // the whole tree below: qsearch searches only captures and quiet promotions,
+  // and both are irreversible and reset the halfmove clock — a promotion is a
+  // pawn move — so neither draw can arise deeper. It sits *after* the
+  // mate/stalemate test above because checkmate outranks the 50-move rule —
+  // movegen has already run by here, so that costs nothing.
   if constexpr (leafnode)
   {
     if (pos.threeMoveRepetition() or pos.fiftyMoveDraw())
@@ -82,20 +83,41 @@ quiescenceSearch(ChessBoard& pos, Score alpha, Score beta, Ply ply, int pvIndex)
 
   if (standPat > alpha) alpha = standPat;
 
-  if (!myMoves.exists<MType::CAPTURES>(pos))
+  // A pawn one push from queening is worth ~800cp more than the static eval
+  // says it is, and a CAPTURES-only move list never sees the push. Promotion-
+  // *captures* carry the capture bit and so arrive with the rest, but a quiet
+  // promotion is emitted under the QUIET bucket. That left every leaf holding a
+  // pawn on the 7th with a clear square ahead of it evaluated as though the
+  // pawn were staying a pawn -- and a leaf is exactly where the search has no
+  // remaining line to discover the truth by other means.
+  //
+  // Not written as `if constexpr`: the runtime `and` folds away just the same
+  // when the flag is off, but both branches still get type-checked, so flipping
+  // USE_QSEARCH_PROMO can never fail to compile the way an untaken
+  // `if constexpr` branch silently can.
+  const bool promoExists = USE_QSEARCH_PROMO and myMoves.exists<MType::PROMOTION>(pos);
+
+  if (!myMoves.exists<MType::CAPTURES>(pos) and !promoExists)
     return alpha;
 
   MoveArray movesArray;
   myMoves.getMoves<MType::CAPTURES>(pos, movesArray);
 
-  // Keep the single best capture at thin nodes, the top 3 otherwise, even if
-  // they lose material -- otherwise a node with only losing captures would
-  // collapse to its stand-pat score.
+  if (promoExists)
+    myMoves.getMoves<MType::PROMOTION>(pos, movesArray);
+
+  // Keep the single best move at thin nodes, the top 3 otherwise, even if they
+  // lose material -- otherwise a node with only losing captures would collapse
+  // to its stand-pat score.
   const size_t floor = movesArray.size() < 4 ? 1 : 3;
 
   // orderCaptures() sorts SEE-descending and hands back the prune boundary, so
   // the loop below never needs a per-move SEE check of its own. Without move
   // ordering the list is unsorted and no such boundary exists -- search it all.
+  // Quiet promotions rank on the same SEE scale as the captures: seeScore()
+  // credits the promoted piece minus the pawn, so an undefended queening is
+  // 810 and sorts above every capture, while one that just hangs the new piece
+  // falls below zero and prunes with the losing captures.
   const size_t moveCount = USE_MOVE_ORDER
     ? orderCaptures(pos, movesArray, floor) : movesArray.size();
 
@@ -103,9 +125,9 @@ quiescenceSearch(ChessBoard& pos, Score alpha, Score beta, Ply ply, int pvIndex)
 
   for (size_t moveNo = 0; moveNo < moveCount; ++moveNo)
   {
-    Move captureMove = movesArray[moveNo];
+    Move qMove = movesArray[moveNo];
 
-    pos.makeMove(captureMove);
+    pos.makeMove(qMove);
     Score score = -quiescenceSearch(pos, -beta, -alpha, ply + 1, pvNextIndex);
     pos.unmakeMove();
 
@@ -121,7 +143,7 @@ quiescenceSearch(ChessBoard& pos, Score alpha, Score beta, Ply ply, int pvIndex)
 
       if (ply < MAX_PLY)
       {
-        pvArray[pvIndex] = filter(captureMove) | quiescenceMove();
+        pvArray[pvIndex] = filter(qMove) | quiescenceMove();
         movcpy (pvArray + pvIndex + 1,
                 pvArray + pvNextIndex, MAX_PLY - ply - 1);
       }

--- a/src/types.h
+++ b/src/types.h
@@ -36,6 +36,7 @@ enum SearchFlag: bool
   USE_RAZOR = true,
   USE_FUTILITY = true,
   USE_HISTORY = true,
+  USE_QSEARCH_PROMO = true,
 };
 
 enum Color: uint8_t


### PR DESCRIPTION
## The gap

`quiescenceSearch` generated `MType::CAPTURES` and nothing else.

Promotion-*captures* were covered — they carry the capture bit (20). But a
**quiet** promotion, a push to the last rank onto an empty square, is emitted
under the QUIET bucket, and qsearch never asked for that bucket. So every leaf
with a pawn on the 7th and a clear square ahead was evaluated as though that
pawn were staying a pawn — an ~810cp error, at exactly the node type with no
remaining line to discover otherwise.

`MType::PROMOTION` existed in the enum but only ever as a *type bit*. It is now
a real `mt1` selector, reusing the QUIET fills with destinations masked to
`Rank18`:

```cpp
constexpr bool quietPawns = hasFlag(mt1, MType::QUIET) or hasFlag(mt1, MType::PROMOTION);
constexpr bool pieceMoves = hasFlag(mt1, MType::QUIET) or hasFlag(mt1, MType::CAPTURES);
constexpr Bitboard quietMask =
  hasFlag(mt1, MType::QUIET) ? Bitboard(AllSquares) : Bitboard(Rank18);

```

## Arena results

Arena: +20.0 Elo [+10.6, +29.5], 3271 games @ 1s+0.1s, 1122W / 1215D / 934L.